### PR TITLE
RTT Support

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -51,3 +51,12 @@ Prints the endian mode of the target hardware.
 
 #### Description
 Tool for updating J-Links on a Windows platform.
+
+
+### Real Time Transfer (RTT)
+
+#### Source
+[RTT](./rtt.py)
+
+#### Description
+Tool for a simple command-line terminal that communicates over RTT.

--- a/examples/rtt.py
+++ b/examples/rtt.py
@@ -59,8 +59,6 @@ def main(target_device):
     print("ctrl-c detected, exiting...")
     pass
 
-  del jlink
-
 
 if __name__ == "__main__":
   sys.exit(main(sys.argv[1]))

--- a/examples/rtt.py
+++ b/examples/rtt.py
@@ -4,9 +4,9 @@ import time
 from builtins import input
 
 try:
-  import thread
+    import thread
 except ImportError:
-  import _thread as thread
+    import _thread as thread
 
 
 def read_rtt(jlink):

--- a/examples/rtt.py
+++ b/examples/rtt.py
@@ -1,3 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Square, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Example RTT terminal.
+#
+# This module creates an interactive terminal with the target using RTT.
+#
+# Usage: rtt target_device
+# Author: Charles Nicholson
+# Date: October 11, 2017
+# Copyright: 2017 Square, Inc.
+
 import pylink
 import sys
 import time
@@ -10,6 +35,23 @@ except ImportError:
 
 
 def read_rtt(jlink):
+    """Reads the JLink RTT buffer #0 at 10Hz and prints to stdout.
+
+    This method is a polling loop against the connected JLink unit. If
+    the JLink is disconnected, it will exit. Additionally, if any exceptions
+    are raised, they will be caught and re-raised after interrupting the
+    main thread.
+
+    sys.stdout.write and sys.stdout.flush are used since target terminals
+    are expected to transmit newlines, which may or may not line up with the
+    arbitrarily-chosen 1024-byte buffer that this loop uses to read.
+
+    Args:
+      jlink (pylink.JLink): The JLink to read.
+
+    Raises:
+      Exception on error.
+    """
     try:
         while jlink.connected():
             terminal_bytes = jlink.rtt_read(0, 1024)
@@ -24,6 +66,21 @@ def read_rtt(jlink):
 
 
 def write_rtt(jlink):
+    """Writes kayboard input to JLink RTT buffer #0.
+
+    This method is a loop that blocks waiting on stdin. When enter is pressed,
+    LF and NUL bytes are added to the input and transmitted as a byte list.
+    If the JLink is disconnected, it will exit gracefully. If any other
+    exceptions are raised, they will be caught and re-raised after interrupting
+    the main thread.
+
+    Args:
+      jlink (pylink.JLink): The JLink to write to.
+
+    Raises:
+      Exception on error.
+    """
+
     try:
         while jlink.connected():
             bytes = list(bytearray(input(), "utf-8") + b"\x0A\x00")
@@ -35,6 +92,24 @@ def write_rtt(jlink):
 
 
 def main(target_device):
+    """Creates an interactive terminal to the target via RTT.
+
+    The main loop opens a connection to the JLink, and then connects
+    to the target device. RTT is started, the number of buffers is presented,
+    and then two worker threads are spawned: one for read, and one for write.
+
+    The main loops sleeps until the JLink is either disconnected or the
+    user hits ctrl-c.
+
+    Args:
+      target_device (string): The target CPU to connect to.
+
+    Returns:
+      Always returns ``0`` or a JLinkException.
+
+    Raises:
+      JLinkException on error.
+    """
     jlink = pylink.JLink()
     print("connecting to JLink...")
     jlink.open()

--- a/examples/rtt.py
+++ b/examples/rtt.py
@@ -5,60 +5,59 @@ import time
 
 
 def read_rtt(jlink):
-  try:
-    while jlink.connected():
-      terminal_bytes = jlink.rtt_read(0, 1024)
-      if terminal_bytes:
-        sys.stdout.write("".join(map(chr, terminal_bytes)))
-        sys.stdout.flush()
-      time.sleep(0.1)
-  except:
-    print("IO read thread exception, exiting...")
-    thread.interrupt_main()
-    raise
+    try:
+        while jlink.connected():
+            terminal_bytes = jlink.rtt_read(0, 1024)
+            if terminal_bytes:
+                sys.stdout.write("".join(map(chr, terminal_bytes)))
+                sys.stdout.flush()
+            time.sleep(0.1)
+    except Exception:
+        print("IO read thread exception, exiting...")
+        thread.interrupt_main()
+        raise
 
 
 def write_rtt(jlink):
-  try:
-    while jlink.connected():
-      bytes = list(bytearray(raw_input()) + b"\x0A" + b"\x00")
-      bytes_written = jlink.rtt_write(0, bytes)
-  except:
-    print("IO write thread exception, exiting...")
-    thread.interrupt_main()
-    raise
+    try:
+        while jlink.connected():
+            bytes = list(bytearray(raw_input()) + b"\x0A" + b"\x00")
+            bytes_written = jlink.rtt_write(0, bytes)
+    except Exception:
+        print("IO write thread exception, exiting...")
+        thread.interrupt_main()
+        raise
 
 
 def main(target_device):
-  jlink = pylink.JLink()
-  print("connecting to JLink...")
-  jlink.open()
-  print("connecting to %s..." % target_device)
-  jlink.set_tif(pylink.enums.JLinkInterfaces.SWD)
-  jlink.connect(target_device)
-  print("connected, starting RTT...")
-  jlink.rtt_start()
+    jlink = pylink.JLink()
+    print("connecting to JLink...")
+    jlink.open()
+    print("connecting to %s..." % target_device)
+    jlink.set_tif(pylink.enums.JLinkInterfaces.SWD)
+    jlink.connect(target_device)
+    print("connected, starting RTT...")
+    jlink.rtt_start()
 
-  while True:
+    while True:
+        try:
+            num_up = jlink.rtt_get_num_up_buffers()
+            num_down = jlink.rtt_get_num_down_buffers()
+            print("RTT started, %d up bufs, %d down bufs." % (num_up, num_down))
+            break
+        except pylink.errors.JLinkRTTException:
+            time.sleep(0.1)
+
     try:
-      num_up = jlink.rtt_get_num_up_buffers()
-      num_down = jlink.rtt_get_num_down_buffers()
-      print("RTT started, %d up bufs, %d down bufs." % (num_up, num_down))
-      break
-    except pylink.errors.JLinkRTTException:
-      time.sleep(0.1)
-      pass
-
-  try:
-    thread.start_new_thread(read_rtt, (jlink,))
-    thread.start_new_thread(write_rtt, (jlink,))
-    while jlink.connected():
-      time.sleep(1)
-    print("JLink disconnected, exiting...")
-  except KeyboardInterrupt:
-    print("ctrl-c detected, exiting...")
-    pass
+        thread.start_new_thread(read_rtt, (jlink,))
+        thread.start_new_thread(write_rtt, (jlink,))
+        while jlink.connected():
+            time.sleep(1)
+        print("JLink disconnected, exiting...")
+    except KeyboardInterrupt:
+        print("ctrl-c detected, exiting...")
+        pass
 
 
 if __name__ == "__main__":
-  sys.exit(main(sys.argv[1]))
+    sys.exit(main(sys.argv[1]))

--- a/examples/rtt.py
+++ b/examples/rtt.py
@@ -1,0 +1,66 @@
+import pylink
+import sys
+import thread
+import time
+
+
+def read_rtt(jlink):
+  try:
+    while jlink.connected():
+      terminal_bytes = jlink.rtt_read(0, 1024)
+      if terminal_bytes:
+        sys.stdout.write("".join(map(chr, terminal_bytes)))
+        sys.stdout.flush()
+      time.sleep(0.1)
+  except:
+    print("IO read thread exception, exiting...")
+    thread.interrupt_main()
+    raise
+
+
+def write_rtt(jlink):
+  try:
+    while jlink.connected():
+      bytes = list(bytearray(raw_input()) + b"\x0A" + b"\x00")
+      bytes_written = jlink.rtt_write(0, bytes)
+  except:
+    print("IO write thread exception, exiting...")
+    thread.interrupt_main()
+    raise
+
+
+def main(target_device):
+  jlink = pylink.JLink()
+  print("connecting to JLink...")
+  jlink.open()
+  print("connecting to %s..." % target_device)
+  jlink.set_tif(pylink.enums.JLinkInterfaces.SWD)
+  jlink.connect(target_device)
+  print("connected, starting RTT...")
+  jlink.rtt_start()
+
+  while True:
+    try:
+      num_up = jlink.rtt_get_num_up_buffers()
+      num_down = jlink.rtt_get_num_down_buffers()
+      print("RTT started, %d up bufs, %d down bufs." % (num_up, num_down))
+      break
+    except pylink.errors.JLinkRTTException:
+      time.sleep(0.1)
+      pass
+
+  try:
+    thread.start_new_thread(read_rtt, (jlink,))
+    thread.start_new_thread(write_rtt, (jlink,))
+    while jlink.connected():
+      time.sleep(1)
+    print("JLink disconnected, exiting...")
+  except KeyboardInterrupt:
+    print("ctrl-c detected, exiting...")
+    pass
+
+  del jlink
+
+
+if __name__ == "__main__":
+  sys.exit(main(sys.argv[1]))

--- a/examples/rtt.py
+++ b/examples/rtt.py
@@ -1,7 +1,12 @@
 import pylink
 import sys
-import thread
 import time
+from builtins import input
+
+try:
+  import thread
+except ImportError:
+  import _thread as thread
 
 
 def read_rtt(jlink):
@@ -21,7 +26,7 @@ def read_rtt(jlink):
 def write_rtt(jlink):
     try:
         while jlink.connected():
-            bytes = list(bytearray(raw_input()) + b"\x0A" + b"\x00")
+            bytes = list(bytearray(input(), "utf-8") + b"\x0A\x00")
             bytes_written = jlink.rtt_write(0, bytes)
     except Exception:
         print("IO write thread exception, exiting...")

--- a/examples/rtt.py
+++ b/examples/rtt.py
@@ -80,7 +80,6 @@ def write_rtt(jlink):
     Raises:
       Exception on error.
     """
-
     try:
         while jlink.connected():
             bytes = list(bytearray(input(), "utf-8") + b"\x0A\x00")

--- a/pylink/enums.py
+++ b/pylink/enums.py
@@ -239,6 +239,29 @@ class JLinkDataErrors(JLinkGlobalErrors):
             return 'Invalid flags passed for the access mask.'
         return super(JLinkDataErrors, cls).to_string(error_code)
 
+class JLinkRTTErrors(JLinkGlobalErrors):
+    """Enumeration for error codes from RTT."""
+
+    RTT_ERROR_CONTROL_BLOCK_NOT_FOUND = -2
+
+    @classmethod
+    def to_string(cls, error_code):
+        """Returns the string message for the given error code.
+
+        Args:
+          cls (JLinkRTTErrors): the ``JLinkRTTErrors`` class
+          error_code (int): error code to convert
+
+        Returns:
+          An error string corresponding to the error code.
+
+        Raises:
+          ValueError: if the error code is invalid.
+        """
+        if error_code == cls.RTT_ERROR_CONTROL_BLOCK_NOT_FOUND:
+          return 'The RTT Control Block has not yet been found (wait?)'
+        return super(JLinkRTTErrors, cls).to_string(error_code)
+
 
 class JLinkHost(object):
     """Enumeration for the different JLink hosts: currently only IP and USB."""

--- a/pylink/enums.py
+++ b/pylink/enums.py
@@ -239,6 +239,7 @@ class JLinkDataErrors(JLinkGlobalErrors):
             return 'Invalid flags passed for the access mask.'
         return super(JLinkDataErrors, cls).to_string(error_code)
 
+
 class JLinkRTTErrors(JLinkGlobalErrors):
     """Enumeration for error codes from RTT."""
 
@@ -259,7 +260,7 @@ class JLinkRTTErrors(JLinkGlobalErrors):
           ValueError: if the error code is invalid.
         """
         if error_code == cls.RTT_ERROR_CONTROL_BLOCK_NOT_FOUND:
-          return 'The RTT Control Block has not yet been found (wait?)'
+            return 'The RTT Control Block has not yet been found (wait?)'
         return super(JLinkRTTErrors, cls).to_string(error_code)
 
 
@@ -707,6 +708,7 @@ class JLinkROMTable(object):
     AHBAP = 0x10E
     SECURE = 0x10F
 
+
 class JLinkRTTCommand(object):
     """RTT commands."""
     START = 0
@@ -714,6 +716,7 @@ class JLinkRTTCommand(object):
     GETDESC = 2
     GETNUMBUF = 3
     GETSTAT = 4
+
 
 class JLinkRTTDirection(object):
     """RTT Direction."""

--- a/pylink/enums.py
+++ b/pylink/enums.py
@@ -683,3 +683,16 @@ class JLinkROMTable(object):
     APBAP = 0x10D
     AHBAP = 0x10E
     SECURE = 0x10F
+
+class JLinkRTTCommand(object):
+    """RTT commands."""
+    START = 0
+    STOP = 1
+    GETDESC = 2
+    GETNUMBUF = 3
+    GETSTAT = 4
+
+class JLinkRTTDirection(object):
+    """RTT Direction."""
+    UP = 0
+    DOWN = 1

--- a/pylink/errors.py
+++ b/pylink/errors.py
@@ -66,6 +66,7 @@ class JLinkDataException(enums.JLinkDataErrors, JLinkException):
     """J-Link data event exception."""
     pass
 
+
 class JLinkRTTException(enums.JLinkRTTErrors, JLinkException):
     """J-Link RTT exception."""
     pass

--- a/pylink/errors.py
+++ b/pylink/errors.py
@@ -65,3 +65,7 @@ class JLinkReadException(enums.JLinkReadErrors, JLinkException):
 class JLinkDataException(enums.JLinkDataErrors, JLinkException):
     """J-Link data event exception."""
     pass
+
+class JLinkRTTException(enums.JLinkRTTErrors, JLinkException):
+    """J-Link RTT exception."""
+    pass

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 class JLink(object):
     """Python interface for the SEGGER J-Link.
 
-    This is a wrapper around the J-Link C SDK to provide a Pythonic interface
+    This is a wrapper around the J-Link C SDK to provide a Python interface
     to it.  The shared library is loaded and used to call the SDK methods.
     """
 

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -4733,7 +4733,7 @@ class JLink(object):
           self (JLink): the ``JLink`` instance
 
         Raises:
-          JLinkException if the underlying JLINK_RTTERMINAL_Control call fails.
+          JLinkRTTException if the underlying JLINK_RTTERMINAL_Control call fails.
         """
 
         self.rtt_control(enums.JLinkRTTCommand.START, None)
@@ -4745,7 +4745,7 @@ class JLink(object):
           self (JLink): the ``JLink`` instance
 
         Raises:
-          JLinkException if the underlying JLINK_RTTERMINAL_Control call fails.
+          JLinkRTTException if the underlying JLINK_RTTERMINAL_Control call fails.
         """
 
         self.rtt_control(enums.JLinkRTTCommand.STOP, None)
@@ -4760,7 +4760,7 @@ class JLink(object):
           The number of configured up buffers on the target.
 
         Raises:
-          JLinkException if the underlying JLINK_RTTERMINAL_Control call fails.
+          JLinkRTTException if the underlying JLINK_RTTERMINAL_Control call fails.
         """
 
         cmd = enums.JLinkRTTCommand.GETNUMBUF
@@ -4777,7 +4777,7 @@ class JLink(object):
           The number of configured down buffers on the target.
 
         Raises:
-          JLinkException if the underlying JLINK_RTTERMINAL_Control call fails.
+          JLinkRTTException if the underlying JLINK_RTTERMINAL_Control call fails.
         """
 
         cmd = enums.JLinkRTTCommand.GETNUMBUF
@@ -4803,14 +4803,14 @@ class JLink(object):
           A list of bytes read from RTT.
 
         Raises:
-          JLinkException if the underlying JLINK_RTTERMINAL_Read call fails.
+          JLinkRTTException if the underlying JLINK_RTTERMINAL_Read call fails.
         """
 
         buf = (ctypes.c_ubyte * num_bytes)()
         bytes_read = self._dll.JLINK_RTTERMINAL_Read(buffer_index, buf, num_bytes)
 
         if bytes_read < 0:
-            raise errors.JLinkException(bytes_read)
+            raise errors.JLinkRTTException(bytes_read)
 
         return list(buf)[:bytes_read]
 
@@ -4830,7 +4830,7 @@ class JLink(object):
           The number of bytes successfully written to the RTT buffer.
 
         Raises:
-          JLinkException if the underlying JLINK_RTTERMINAL_Write call fails.
+          JLinkRTTException if the underlying JLINK_RTTERMINAL_Write call fails.
         """
 
         buf_size = len(data)
@@ -4838,7 +4838,7 @@ class JLink(object):
         bytes_written = self._dll.JLINK_RTTERMINAL_Write(buffer_index, buf, buf_size)
 
         if bytes_written < 0:
-            raise errors.JLinkException(bytes_written)
+            raise errors.JLinkRTTException(bytes_written)
 
         return bytes_written
 
@@ -4862,7 +4862,7 @@ class JLink(object):
         res = self._dll.JLINK_RTTERMINAL_Control(command, config_byref)
 
         if res < 0:
-            raise errors.JLinkException(res)
+            raise errors.JLinkRTTException(res)
 
         return res
 

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -4784,7 +4784,6 @@ class JLink(object):
         dir = ctypes.c_int(enums.JLinkRTTDirection.DOWN)
         return self.rtt_control(cmd, dir)
 
-
     @open_required
     def rtt_read(self, buffer_index, num_bytes):
         """Reads data from the RTT buffer.
@@ -4865,5 +4864,3 @@ class JLink(object):
             raise errors.JLinkRTTException(res)
 
         return res
-
-

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -4735,7 +4735,6 @@ class JLink(object):
         Raises:
           JLinkRTTException if the underlying JLINK_RTTERMINAL_Control call fails.
         """
-
         self.rtt_control(enums.JLinkRTTCommand.START, None)
 
     @open_required
@@ -4747,7 +4746,6 @@ class JLink(object):
         Raises:
           JLinkRTTException if the underlying JLINK_RTTERMINAL_Control call fails.
         """
-
         self.rtt_control(enums.JLinkRTTCommand.STOP, None)
 
     @open_required
@@ -4762,7 +4760,6 @@ class JLink(object):
         Raises:
           JLinkRTTException if the underlying JLINK_RTTERMINAL_Control call fails.
         """
-
         cmd = enums.JLinkRTTCommand.GETNUMBUF
         dir = ctypes.c_int(enums.JLinkRTTDirection.UP)
         return self.rtt_control(cmd, dir)
@@ -4779,7 +4776,6 @@ class JLink(object):
         Raises:
           JLinkRTTException if the underlying JLINK_RTTERMINAL_Control call fails.
         """
-
         cmd = enums.JLinkRTTCommand.GETNUMBUF
         dir = ctypes.c_int(enums.JLinkRTTDirection.DOWN)
         return self.rtt_control(cmd, dir)
@@ -4804,7 +4800,6 @@ class JLink(object):
         Raises:
           JLinkRTTException if the underlying JLINK_RTTERMINAL_Read call fails.
         """
-
         buf = (ctypes.c_ubyte * num_bytes)()
         bytes_read = self._dll.JLINK_RTTERMINAL_Read(buffer_index, buf, num_bytes)
 
@@ -4831,7 +4826,6 @@ class JLink(object):
         Raises:
           JLinkRTTException if the underlying JLINK_RTTERMINAL_Write call fails.
         """
-
         buf_size = len(data)
         buf = (ctypes.c_ubyte * buf_size)(*bytearray(data))
         bytes_written = self._dll.JLINK_RTTERMINAL_Write(buffer_index, buf, buf_size)
@@ -4856,7 +4850,6 @@ class JLink(object):
         Returns:
           An integer containing the result of the command.
         """
-
         config_byref = ctypes.byref(config) if config is not None else None
         res = self._dll.JLINK_RTTERMINAL_Control(command, config_byref)
 

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -4719,3 +4719,60 @@ class JLink(object):
         bytes_read = self._dll.JLINKARM_SWO_ReadStimulus(port, buf, buf_size)
 
         return list(buf)[:bytes_read]
+
+    @connection_required
+    def rtt_read(self, buffer_index, num_bytes):
+        """Reads data from the RTT buffer.
+
+        This method will read at most num_bytes bytes from the specified
+        RTT buffer. The data is automatically removed from the RTT buffer.
+        If there are not num_bytes bytes waiting in the RTT buffer, the
+        entire contents of the RTT buffer will be read.
+
+        Args:
+          self (JLink): the ``JLink`` instance
+          buffer_index (int): the index of the RTT buffer to read from
+          num_bytes (int): the maximum number of bytes to read
+
+        Returns:
+          A list of bytes read from RTT.
+
+        Raises:
+          JLinkException if the underlying JLINK_RTTERMINAL_Read call fails.
+        """
+
+        buf = (ctypes.c_ubyte * num_bytes)()
+        bytes_read = self._dll.JLINK_RTTERMINAL_Read(buffer_index, buf, num_bytes)
+
+        if bytes_read < 0:
+            raise errors.JLinkException(bytes_read)
+
+        return list(buf)[:bytes_read]
+
+    @connection_required
+    def rtt_write(self, buffer_index, data):
+        """Writes data to the RTT buffer.
+
+        This method will write at most len(data) bytes to the specified RTT
+        buffer.
+
+        Args:
+          self (JLink): the ``JLink`` instance
+          buffer_index (int): the index of the RTT buffer to write to
+          data (list): the list of bytes to write to the RTT buffer
+
+        Returns:
+          The number of bytes successfully written to the RTT buffer.
+
+        Raises:
+          JLinkException if the underlying JLINK_RTTERMINAL_Write call fails.
+        """
+
+        buf_size = len(data)
+        buf = (ctypes.c_ubyte * buf_size)(*bytearray(data))
+        bytes_written = self._dll.JLINK_RTTERMINAL_Write(buffer_index, buf, buf_size)
+
+        if bytes_written < 0:
+            raise errors.JLinkException(bytes_written)
+
+        return bytes_written

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 behave == 1.2.5
 coverage == 4.4.1
+future
 psutil >= 5.2.2
 pycodestyle >= 2.3.1
 sphinx == 1.4.8

--- a/setup.py
+++ b/setup.py
@@ -255,7 +255,8 @@ setuptools.setup(
 
     # Dependencies.
     install_requires=[
-        'psutil >= 5.2.2'
+        'psutil >= 5.2.2',
+        'future'
     ],
 
     # Tests

--- a/setup.py
+++ b/setup.py
@@ -192,10 +192,12 @@ class BDDTestCommand(setuptools.Command):
             original_dir = os.getcwd()
             os.chdir(d)
 
+            output = ''
             try:
                 output = subprocess.check_output('make', shell=True, stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError as e:
-                sys.stdout.write('Captured Output:%s%s%s' % (os.linesep, output, os.linesep))
+                if output:
+                    sys.stdout.write('Captured Output:%s%s%s' % (os.linesep, output, os.linesep))
                 os.chdir(original_dir)
                 raise e
 

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -5378,7 +5378,6 @@ class TestJLink(unittest.TestCase):
         Returns:
           ``None``
         """
-
         self.dll.JLINK_RTTERMINAL_Control.return_value = 0
         self.jlink.rtt_start()
         actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0]
@@ -5393,7 +5392,6 @@ class TestJLink(unittest.TestCase):
         Returns:
           ``None``
         """
-
         self.dll.JLINK_RTTERMINAL_Control.return_value = 0
         self.jlink.rtt_stop()
         actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0]
@@ -5408,7 +5406,6 @@ class TestJLink(unittest.TestCase):
         Returns:
           ``None``
         """
-
         self.dll.JLINK_RTTERMINAL_Control.return_value = 0
         self.jlink.rtt_get_num_up_buffers()
         actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0]
@@ -5423,7 +5420,6 @@ class TestJLink(unittest.TestCase):
         Returns:
           ``None``
         """
-
         expected = 2345
         self.dll.JLINK_RTTERMINAL_Control.return_value = expected
         actual = self.jlink.rtt_get_num_up_buffers()
@@ -5437,7 +5433,6 @@ class TestJLink(unittest.TestCase):
         Returns:
           ``None``
         """
-
         self.dll.JLINK_RTTERMINAL_Control.return_value = 0
         self.jlink.rtt_get_num_down_buffers()
         actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0]
@@ -5452,7 +5447,6 @@ class TestJLink(unittest.TestCase):
         Returns:
           ``None``
         """
-
         expected = 2345
         self.dll.JLINK_RTTERMINAL_Control.return_value = expected
         actual = self.jlink.rtt_get_num_down_buffers()

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -5593,7 +5593,7 @@ class TestJLink(unittest.TestCase):
         Returns:
           ``None``
         """
-        expected = 1234;
+        expected = 1234
         self.dll.JLINK_RTTERMINAL_Write.return_value = expected
         actual = self.jlink.rtt_write(0, [])
         self.assertEqual(actual, expected)

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -5370,6 +5370,141 @@ class TestJLink(unittest.TestCase):
         self.assertTrue(isinstance(res, list))
         self.assertEqual(num_bytes, len(res))
 
+    def test_rtt_start_calls_rtt_control_with_START_command(self):
+        """Tests that rtt_start calls RTTERMINAL_Control with start command.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+
+        self.jlink.rtt_start()
+        actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0]
+        self.assertEqual(enums.JLinkRTTCommand.START, actual[0])
+        self.assertIsNone(actual[1])
+
+    def test_rtt_stop_calls_rtt_control_with_STOP_command(self):
+        """Tests that rtt_stop calls RTTERMINAL_Control with stop command.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+
+        self.jlink.rtt_stop()
+        actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0]
+        self.assertEqual(enums.JLinkRTTCommand.STOP, actual[0])
+        self.assertIsNone(actual[1])
+
+    def test_rtt_get_num_up_buffers_calls_control_with_cmd_and_dir(self):
+        """Tests that rtt_get_num_up_buffers calls RTTERMINAL_Control.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+
+        self.jlink.rtt_get_num_up_buffers()
+        actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0]
+        self.assertEqual(enums.JLinkRTTCommand.GETNUMBUF, actual[0])
+        self.assertEqual(enums.JLinkRTTDirection.UP, actual[1]._obj.value)
+
+    def test_rtt_get_num_up_buffers_returns_result_from_control(self):
+        """Tests that rtt_get_num_up_buffers returns RTTERMINAL_Control.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+
+        expected = 2345
+        self.dll.JLINK_RTTERMINAL_Control.return_value = expected
+        actual = self.jlink.rtt_get_num_up_buffers()
+        self.assertEqual(actual, expected)
+
+    def test_rtt_get_num_down_buffers_calls_control_with_cmd_and_dir(self):
+        """Tests that rtt_get_num_down_buffers calls RTTERMINAL_Control.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+
+        self.jlink.rtt_get_num_down_buffers()
+        actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0]
+        self.assertEqual(enums.JLinkRTTCommand.GETNUMBUF, actual[0])
+        self.assertEqual(enums.JLinkRTTDirection.DOWN, actual[1]._obj.value)
+
+    def test_rtt_get_num_down_buffers_returns_result_from_control(self):
+        """Tests that rtt_get_num_down_buffers returns RTTERMINAL_Control.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+
+        expected = 2345
+        self.dll.JLINK_RTTERMINAL_Control.return_value = expected
+        actual = self.jlink.rtt_get_num_down_buffers()
+        self.assertEqual(actual, expected)
+
+    def test_rtt_control_forwards_command_to_RTTERMINAL_Control(self):
+        """Tests that rtt_control forwards the command to RTT.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        expected = 1234
+        self.jlink.rtt_control(expected, None)
+        actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0][0]
+        self.assertEqual(actual, expected)
+
+    def test_rtt_control_forwards_none_config_to_RTTERMINAL_Control(self):
+        """Tests that a None config value is forwarded to RTTERMINAL_Control.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        self.jlink.rtt_control(0, None)
+        self.assertIsNone(self.dll.JLINK_RTTERMINAL_Control.call_args[0][1])
+
+    def test_rtt_control_wraps_config_in_byref_before_calling_Control(self):
+        """Tests that non-None configs get wrapped in ctypes.byref.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        expected = 1234
+        config = ctypes.c_int(expected)
+        self.jlink.rtt_control(0, config)
+        actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0][1]
+        self.assertIs(type(actual), type(ctypes.byref(ctypes.c_int())))
+        self.assertEqual(actual._obj.value, expected)
+
+    def test_rtt_control_raises_error_if_RTTERMINAL_Control_fails(self):
+        """Tests that a JLinkException is raised if RTTERMINAL_Control fails.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        self.dll.JLINK_RTTERMINAL_Control.return_value = -1
+        with self.assertRaises(JLinkException):
+            self.jlink.rtt_control(0, None)
+
     def test_rtt_read_forwards_buffer_index_to_RTTERMINAL_Read(self):
         """Tests that rtt_read calls RTTERMINAL_Read with the supplied index.
         Args:

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -5370,6 +5370,111 @@ class TestJLink(unittest.TestCase):
         self.assertTrue(isinstance(res, list))
         self.assertEqual(num_bytes, len(res))
 
+    def test_rtt_read_forwards_buffer_index_to_RTTERMINAL_Read(self):
+        """Tests that rtt_read calls RTTERMINAL_Read with the supplied index.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        expected = 3
+        self.dll.JLINK_RTTERMINAL_Read.return_value = 0
+        self.jlink.rtt_read(expected, 0)
+        self.assertEqual(self.dll.JLINK_RTTERMINAL_Read.call_args[0][0], expected)
+
+    def test_rtt_read_returns_partial_payload_when_underfilled(self):
+        """Tests that rtt_read returns fewer bytes than requested when not full.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        num_bytes = 16
+        actual_bytes = 5
+        self.dll.JLINK_RTTERMINAL_Read.return_value = actual_bytes
+        res = self.jlink.rtt_read(0, num_bytes)
+        self.assertEqual(len(res), actual_bytes)
+
+    def test_rtt_read_returns_list_sized_from_RTTERMINAL_Read(self):
+        """Tests that rtt_read returns however many bytes were read from RTT.
+
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        expected = 123
+        self.dll.JLINK_RTTERMINAL_Read.return_value = expected
+        res = self.jlink.rtt_read(0, expected)
+        self.assertEqual(len(res), expected)
+
+    def test_rtt_read_raises_exception_if_RTTERMINAL_Read_fails(self):
+        """Tests that rtt_read raises a JLinkException on failure.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        self.dll.JLINK_RTTERMINAL_Read.return_value = -1
+        with self.assertRaises(JLinkException):
+            self.jlink.rtt_read(0, 0)
+
+    def test_rtt_write_forwards_buffer_index_to_RTTERMINAL_Write(self):
+        """Tests that rtt_write calls RTTERMINAL_Write with the supplied index.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        expected = 89
+        self.dll.JLINK_RTTERMINAL_Write.return_value = 0
+        self.jlink.rtt_write(expected, [])
+        self.assertEqual(self.dll.JLINK_RTTERMINAL_Write.call_args[0][0], expected)
+
+    def test_rtt_write_converts_byte_list_to_ctype_array(self):
+        """Tests that rtt_write converts the provided byte list to ctype.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        expected = '\x00\x01\x02\x03'
+        self.dll.JLINK_RTTERMINAL_Write.return_value = 0
+        self.jlink.rtt_write(0, expected)
+        actual = bytearray(self.dll.JLINK_RTTERMINAL_Write.call_args[0][1])
+        self.assertEqual(actual, expected)
+
+    def test_rtt_write_returns_result_from_RTTERMINAL_Write(self):
+        """Tests that rtt_write returns whatever value RTTERMINAL_Write returns.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        expected = 1234;
+        self.dll.JLINK_RTTERMINAL_Write.return_value = expected
+        actual = self.jlink.rtt_write(0, [])
+        self.assertEqual(actual, expected)
+
+    def test_rtt_write_raises_exception_if_RTTERMINAL_Write_fails(self):
+        """Tests that rtt_write raises a JLinkException on failure.
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        self.dll.JLINK_RTTERMINAL_Write.return_value = -1
+        with self.assertRaises(JLinkException):
+            self.jlink.rtt_write(0, [])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -5379,6 +5379,7 @@ class TestJLink(unittest.TestCase):
           ``None``
         """
 
+        self.dll.JLINK_RTTERMINAL_Control.return_value = 0
         self.jlink.rtt_start()
         actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0]
         self.assertEqual(enums.JLinkRTTCommand.START, actual[0])
@@ -5393,6 +5394,7 @@ class TestJLink(unittest.TestCase):
           ``None``
         """
 
+        self.dll.JLINK_RTTERMINAL_Control.return_value = 0
         self.jlink.rtt_stop()
         actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0]
         self.assertEqual(enums.JLinkRTTCommand.STOP, actual[0])
@@ -5407,6 +5409,7 @@ class TestJLink(unittest.TestCase):
           ``None``
         """
 
+        self.dll.JLINK_RTTERMINAL_Control.return_value = 0
         self.jlink.rtt_get_num_up_buffers()
         actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0]
         self.assertEqual(enums.JLinkRTTCommand.GETNUMBUF, actual[0])
@@ -5435,6 +5438,7 @@ class TestJLink(unittest.TestCase):
           ``None``
         """
 
+        self.dll.JLINK_RTTERMINAL_Control.return_value = 0
         self.jlink.rtt_get_num_down_buffers()
         actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0]
         self.assertEqual(enums.JLinkRTTCommand.GETNUMBUF, actual[0])
@@ -5463,6 +5467,7 @@ class TestJLink(unittest.TestCase):
           ``None``
         """
         expected = 1234
+        self.dll.JLINK_RTTERMINAL_Control.return_value = 0
         self.jlink.rtt_control(expected, None)
         actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0][0]
         self.assertEqual(actual, expected)
@@ -5475,6 +5480,7 @@ class TestJLink(unittest.TestCase):
         Returns:
           ``None``
         """
+        self.dll.JLINK_RTTERMINAL_Control.return_value = 0
         self.jlink.rtt_control(0, None)
         self.assertIsNone(self.dll.JLINK_RTTERMINAL_Control.call_args[0][1])
 
@@ -5488,6 +5494,7 @@ class TestJLink(unittest.TestCase):
         """
         expected = 1234
         config = ctypes.c_int(expected)
+        self.dll.JLINK_RTTERMINAL_Control.return_value = 0
         self.jlink.rtt_control(0, config)
         actual = self.dll.JLINK_RTTERMINAL_Control.call_args[0][1]
         self.assertIs(type(actual), type(ctypes.byref(ctypes.c_int())))
@@ -5579,7 +5586,7 @@ class TestJLink(unittest.TestCase):
         Returns:
           ``None``
         """
-        expected = '\x00\x01\x02\x03'
+        expected = b'\x00\x01\x02\x03'
         self.dll.JLINK_RTTERMINAL_Write.return_value = 0
         self.jlink.rtt_write(0, expected)
         actual = bytearray(self.dll.JLINK_RTTERMINAL_Write.call_args[0][1])
@@ -5595,7 +5602,7 @@ class TestJLink(unittest.TestCase):
         """
         expected = 1234
         self.dll.JLINK_RTTERMINAL_Write.return_value = expected
-        actual = self.jlink.rtt_write(0, [])
+        actual = self.jlink.rtt_write(0, b'')
         self.assertEqual(actual, expected)
 
     def test_rtt_write_raises_exception_if_RTTERMINAL_Write_fails(self):


### PR DESCRIPTION
This PR adds support for the SEGGER RTT system:
https://www.segger.com/products/debug-probes/j-link/technology/real-time-transfer/about-real-time-transfer/

New methods are added to the `JLink` class:

```JLink.rtt_start
JLink.rtt_stop
JLink.rtt_read
JLink.rtt_write
JLink.rtt_get_num_up_buffers
JLink.rtt_get_num_down_buffers
JLink.rtt_control
```

`JLink.rtt_start`, `JLink.rtt_stop`, `JLink.rtt_get_num_up_buffers`, and `JLink.rtt_get_num_down_buffers` are all implemented purely in terms of `JLink.rtt_control`, which has an unpleasant and non-intuitive interface (though should probably be exposed anyway, just not endorsed).

The only RTT control feature that is not exposed in this PR is GETDESC, which exposes interesting details about a buffer (name, size, control flags). It's not urgent for our current needs, so it's not part of this PR, though it is straightforward to implement in terms of `JLink.rtt_control`.

All functions are fully unit-tested, with the exception of `JLink.rtt_read`. It wasn't obvious to me how to have the mock version of `JLINK_RTTERMINAL_Read` modify the data buffer, so the buffer-slicing behavior of `JLink.rtt_read` when fewer bytes are present than requested is untested (jlink.py:4815). Suggestions welcome, I'm new to mocking in Python.

Additionally, a new RTT example is provided: It connects to a JLink, opens a target connection, initializes RTT, and spins up two threads (1 for reading kb input, 1 for printing RTT output). I haven't tested it on Windows but it should be platform-agnostic.

I don't have a K21 TWR board here, but it would be pretty simple for someone at Square to add a corresponding firmware image that echoes or responds to basic RTT commands; the target half of the RTT example. Hopefully the Python-only example is useful, though.

Feedback welcome!