### PR TITLE
Wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ deploy:
   on:
     branch: master
     tags: true
+  distributions: "sdist bdist_wheel"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 script:
   - pycodestyle .
   - python setup.py test
+  - python setup.py bdist_wheel
 
 deploy:
   provider: pypi

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ sphinx-argparse == 0.1.15
 sphinx_rtd_theme == 0.1.10a0
 sphinxcontrib-napoleon == 0.5.3
 wheel
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ sphinx == 1.4.8
 sphinx-argparse == 0.1.15
 sphinx_rtd_theme == 0.1.10a0
 sphinxcontrib-napoleon == 0.5.3
+wheel
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,9 @@ exclude = .eggs
 [metadata]
 description-file = README.md
 
+[bdist_wheel]
+universal = 1
+
 [behave]
 color = True
 summary = True


### PR DESCRIPTION
Add wheel support:

The `wheel` package is added to `requirements.txt`.
The `universal = 1` configuration is added to `setup.cfg`.

Since pylink works on both Python2 and Python3, we can use the `universal` option.