### PR TITLE
Fix error reading 32bit register with MSB set

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -2416,7 +2416,8 @@ class JLink(object):
         Returns:
           The integer read from the input buffer.
         """
-        return abs(self._dll.JLINK_SWD_GetU32(offset))
+        value = self._dll.JLINK_SWD_GetU32(offset)
+        return ctypes.c_ulong(value).value
 
     @interface_required(enums.JLinkInterfaces.SWD)
     @connection_required


### PR DESCRIPTION
The old code with abs() function did a 2's complement, if the value had MSB set (e.g. 0x80000000). Fixed code makes the value unsigned and returns the raw binary value and everything works as expected.