### PR TITLE
Address remaining casting issues in readXX

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Square, Inc.
+# Copyright 2018 Square, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -2388,7 +2388,8 @@ class JLink(object):
         Returns:
           The integer read from the input buffer.
         """
-        return self._dll.JLINK_SWD_GetU8(offset)
+        value = self._dll.JLINK_SWD_GetU8(offset)
+        return ctypes.c_uint8(value).value
 
     @interface_required(enums.JLinkInterfaces.SWD)
     @connection_required
@@ -2402,7 +2403,8 @@ class JLink(object):
         Returns:
           The integer read from the input buffer.
         """
-        return self._dll.JLINK_SWD_GetU16(offset)
+        value = self._dll.JLINK_SWD_GetU16(offset)
+        return ctypes.c_uint16(value).value
 
     @interface_required(enums.JLinkInterfaces.SWD)
     @connection_required
@@ -2417,7 +2419,7 @@ class JLink(object):
           The integer read from the input buffer.
         """
         value = self._dll.JLINK_SWD_GetU32(offset)
-        return ctypes.c_ulong(value).value
+        return ctypes.c_uint32(value).value
 
     @interface_required(enums.JLinkInterfaces.SWD)
     @connection_required

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Square, Inc.
+# Copyright 2018 Square, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -270,6 +270,8 @@ class TestJLink(unittest.TestCase):
         self.assertEqual(enums.JLinkInterfaces.JTAG, my_jlink.tif)
 
         my_jlink._tif = enums.JLinkInterfaces.SWD
+
+        self.dll.JLINK_SWD_GetU8.return_value = 0
         my_jlink.swd_read8(0)
 
     def test_jlink_opened(self):


### PR DESCRIPTION
@hkpeprah It looks like we were relying on Python to properly handle signedness coming back from ctypes, which is failing for addresses above 0x8000000. I've updated the remaining readXX functions to cast to the appropriate C type before returning for consistency. I had to get a little creative in one of the tests since it appeared that the mocked JLINK_SWD_GetU8 was not returning an integer type.

WDYT?