### PR TITLE
[Bug] Remove Python 3.7 build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ os:
 python:
   - '2.7'
   - '3.6'
-  - '3.7-dev' # 3.7 development branch
 
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
## Bug: Remove Python 3.7 build on Travis
### Description
@charlesnicholson's [PR](https://github.com/square/pylink/pull/21) seems to be having issues with Python 3.7.  We should remove the development branch as changes will periodically role in, and re-introduce it once it's stable.