### PR TITLE
[Task] Only deploy using the Python 2.7 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ deploy:
   on:
     branch: master
     tags: true
+  python: 2.7
   distributions: "sdist bdist_wheel"
 
 addons:


### PR DESCRIPTION
## Task: Only deploy using the Python 2.7 build
### Description
Travis provides the option to only deploy the package on a specific build.  Right now we occasionally get [failures](https://travis-ci.org/square/pylink/builds/352976449) on deploy because one build has already uploaded.  Though this causes no issue currently, it'd be nice for the deploy to always be green.