### PR TITLE
[Task] Add missing six requirement to PyLink

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ coverage == 4.4.1
 future
 psutil >= 5.2.2
 pycodestyle >= 2.3.1
+six
 sphinx == 1.4.8
 sphinx-argparse == 0.1.15
 sphinx_rtd_theme == 0.2.4

--- a/setup.py
+++ b/setup.py
@@ -256,7 +256,8 @@ setuptools.setup(
     # Dependencies.
     install_requires=[
         'psutil >= 5.2.2',
-        'future'
+        'future',
+        'six'
     ],
 
     # Tests


### PR DESCRIPTION
## Task: Add missing six requirement to PyLink
### Description
Noticed one time when doing a bare virtual environment that `six` was a dependency.