### PR TITLE
[Task] Fix linting rules for Python 3.7

### DIFF
--- a/pylink/decorators.py
+++ b/pylink/decorators.py
@@ -17,7 +17,7 @@ from . import threads
 import functools
 
 
-def async(func):
+def async_decorator(func):
     """Asynchronous function decorator.  Interprets the function as being
     asynchronous, so returns a function that will handle calling the
     Function asynchronously.

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -2103,7 +2103,7 @@ class JLink(object):
         return True
 
     @connection_required
-    @decorators.async
+    @decorators.async_decorator
     def halt(self):
         """Halts the CPU Core.
 

--- a/pylink/library.py
+++ b/pylink/library.py
@@ -173,7 +173,7 @@ class Library(object):
         ======== ============================================================
         Versions Directory
         ======== ============================================================
-        < 5.0.0  ``/Applications/SEGGER/JLink\ NUMBER``
+        < 5.0.0  ``/Applications/SEGGER/JLink\\ NUMBER``
         < 6.0.0  ``/Applications/SEGGER/JLink/libjlinkarm.major.minor.dylib``
         >= 6.0.0 ``/Applications/SEGGER/JLink/libjlinkarm``
         ======== ============================================================

--- a/pylink/unlockers/unlock_kinetis.py
+++ b/pylink/unlockers/unlock_kinetis.py
@@ -247,7 +247,7 @@ def unlock_kinetis_jtag(jlink):
 UNLOCK_METHODS[enums.JLinkInterfaces.JTAG] = unlock_kinetis_jtag
 
 
-@decorators.async
+@decorators.async_decorator
 def unlock_kinetis(jlink):
     """Unlock for Freescale Kinetis K40 or K60 device.
 

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -58,7 +58,7 @@ class TestDecorators(unittest.TestCase):
         Returns:
           `None`
         """
-        @decorators.async
+        @decorators.async_decorator
         def foo():
             return 4
 
@@ -74,7 +74,7 @@ class TestDecorators(unittest.TestCase):
         Returns:
           `None`
         """
-        @decorators.async
+        @decorators.async_decorator
         def foo():
             return 4
 
@@ -90,7 +90,7 @@ class TestDecorators(unittest.TestCase):
         Returns:
           `None`
         """
-        @decorators.async
+        @decorators.async_decorator
         def foo():
             return 4
 
@@ -120,7 +120,7 @@ class TestDecorators(unittest.TestCase):
         Returns:
           `None`
         """
-        @decorators.async
+        @decorators.async_decorator
         def failure():
             raise Exception('I HAVE FAILED!')
 


### PR DESCRIPTION
## Task: Fix linting rules for Python 3.7
### Description
Fixes the new lint rules for Python 3.7.

```
./pylink/decorators.py:20:5: W606 'async' and 'await' are reserved keywords starting with Python 3.7
./pylink/jlink.py:2106:17: W606 'async' and 'await' are reserved keywords starting with Python 3.7
./pylink/library.py:186:-384: W605 invalid escape sequence '\ '
./pylink/unlockers/unlock_kinetis.py:250:13: W606 'async' and 'await' are reserved keywords starting with Python 3.7
./tests/unit/test_decorators.py:61:21: W606 'async' and 'await' are reserved keywords starting with Python 3.7
./tests/unit/test_decorators.py:77:21: W606 'async' and 'await' are reserved keywords starting with Python 3.7
./tests/unit/test_decorators.py:93:21: W606 'async' and 'await' are reserved keywords starting with Python 3.7
./tests/unit/test_decorators.py:123:21: W606 'async' and 'await' are reserved keywords starting with Python 3.7
```