### PR TITLE
[Feature] RTT Control Buffer and Status

### DIFF
--- a/pylink/structs.py
+++ b/pylink/structs.py
@@ -1101,3 +1101,163 @@ class JLinkTraceRegion(ctypes.Structure):
           String representation of the trace region.
         """
         return '%s(Index=%d)' % (self.__class__.__name__, self.RegionIndex)
+
+
+class JLinkRTTerminalStart(ctypes.Structure):
+    """Structure used to configure an RTT instance.
+
+    Attributes:
+      ConfigBlockAddress: Address of the RTT block.
+    """
+    _fields_ = [
+        ('ConfigBlockAddress', ctypes.c_uint32),
+        ('Reserved', ctypes.c_uint32 * 3)
+    ]
+
+    def __repr__(self):
+        """Returns a string representation of the instance.
+
+        Args:
+          self (JLinkRTTerminalStart): RTT start instance.
+
+        Returns:
+          String representation of the instance.
+        """
+        return '%s(ConfigAddress=0x%X)' % (self.__class__.__name__, self.ConfigBlockAddress)
+
+    def __str__(self):
+        """Returns a string representation of the instance.
+
+        Args:
+          self (JLinkRTTerminalStart): RTT start instance.
+
+        Returns:
+          String representation of the instance.
+        """
+        return self.__repr__()
+
+
+class JLinkRTTerminalBufDesc(ctypes.Structure):
+    """Structure describing a RTT buffer.
+
+    Attributes:
+      BufferIndex: index of the buffer to request information about.
+      Direction: direction of the upper (`0` for up, `1` for Down).
+      acName: Name of the buffer.
+      SizeOfBuffer: size of the buffer in bytes.
+      Flags: flags set on the buffer.
+    """
+    _fields_ = [
+        ('BufferIndex', ctypes.c_int32),
+        ('Direction', ctypes.c_uint32),
+        ('acName', ctypes.c_char * 32),
+        ('SizeOfBuffer', ctypes.c_uint32),
+        ('Flags', ctypes.c_uint32)
+    ]
+
+    def __repr__(self):
+        """Returns a string representation of the instance.
+
+        Args:
+          self (JLinkRTTerminalBufDesc): the terminal buffer descriptor.
+
+        Returns:
+          String representation of the buffer descriptor.
+        """
+        return '%s(Index=%d, Name=%s)' % (self.__class__.__name__, self.BufferIndex, self.name)
+
+    def __str__(self):
+        """Returns a string representation of the instance.
+
+        Args:
+          self (JLinkRTTerminalBufDesc): the terminal buffer descriptor.
+
+        Returns:
+          String representation of the buffer descriptor.
+        """
+        dir_string = 'up' if self.up else 'down'
+        return '%s <Index=%d, Direction=%s, Size=%s>' % (self.name, self.BufferIndex,
+                                                         dir_string, self.SizeOfBuffer)
+
+    @property
+    def up(self):
+        """Returns a boolean indicating if the buffer is an 'UP' buffer.
+
+        Args:
+          self (JLinkRTTerminalBufDesc): the terminal buffer descriptor.
+
+        Returns:
+          ``True`` if the buffer is an 'UP' buffer, otherwise ``False``.
+        """
+        return (self.Direction == 0)
+
+    @property
+    def down(self):
+        """Returns a boolean indicating if the buffer is an 'DOWN' buffer.
+
+        Args:
+          self (JLinkRTTerminalBufDesc): the terminal buffer descriptor.
+
+        Returns:
+          ``True`` if the buffer is an 'DOWN' buffer, otherwise ``False``.
+        """
+        return (self.Direction == 1)
+
+    @property
+    def name(self):
+        """Returns the name of the buffer.
+
+        Args:
+          self (JLinkRTTerminalBufDesc): the terminal buffer descriptor.
+
+        Returns:
+          String name of the buffer.
+        """
+        return self.acName.decode()
+
+
+class JLinkRTTerminalStatus(ctypes.Structure):
+    """Structure describing the status of the RTT terminal.
+
+    Attributes:
+      NumBytesTransferred: number of bytes sent to the client application.
+      NumBytesRead: number of bytes read from the target.
+      HostOverflowCount: number of overflows on the host.
+      IsRunning: if RTT is running.
+      NumUpBuffers: number of 'UP' buffers.
+      NumDownBuffers: number of 'DOWN' buffers.
+    """
+    _fields_ = [
+        ('NumBytesTransferred', ctypes.c_uint32),
+        ('NumBytesRead', ctypes.c_uint32),
+        ('HostOverflowCount', ctypes.c_int),
+        ('IsRunning', ctypes.c_int),
+        ('NumUpBuffers', ctypes.c_int),
+        ('NumDownBuffers', ctypes.c_int),
+        ('Reserved', ctypes.c_uint32 * 2)
+    ]
+
+    def __repr__(self):
+        """Returns a string representation of the instance.
+
+        Args:
+          self (JLinkRTTerminalStatus): the status instance.
+
+        Returns:
+          Strings representation of the status.
+        """
+        return '%s(NumUpBuffers=%d, NumDownBuffers=%d)' % (self.__class__.__name__,
+                                                           self.NumUpBuffers, self.NumDownBuffers)
+
+    def __str__(self):
+        """Returns a string representation of the instance.
+
+        Args:
+          self (JLinkRTTerminalStatus): the status instance.
+
+        Returns:
+          Strings representation of the status.
+        """
+        return 'Status <NumUpBuffers=%d, NumDownBuffers=%d, Running=%s>' % (self.NumUpBuffers,
+                                                                            self.NumDownBuffers,
+                                                                            self.IsRunning)

--- a/tests/functional/features/jlink/rtt.feature
+++ b/tests/functional/features/jlink/rtt.feature
@@ -1,0 +1,15 @@
+@connection
+Feature: RTT
+    In order to debug my firmware
+    I want to be able to use RTT
+    To write and receive real-time debug information
+
+    Scenario: Echoing data over RTT
+        Given my J-Link is connected
+        And target interface SWD
+        And device MK21FX512xxx12 (ALLOW SECURITY)
+        When I flash the firmware K21-RTT
+        And I reset my device
+        And I enable RTT with config block 0x1FFF0424
+        When I write "aardvark" to RTT channel 0
+        Then I should read "aardvark" on RTT channel 0

--- a/tests/functional/features/steps/rtt.py
+++ b/tests/functional/features/steps/rtt.py
@@ -1,0 +1,85 @@
+# Copyright 2019 Square, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import behave
+import pylink
+
+import time
+
+
+@behave.when('I enable RTT with config block {block_address}')
+def step_enable_rtt(context, block_address):
+    """Enables RTT.
+
+    Args:
+      context (Context): the ``Context`` instance
+      block_address (str): the RTT config block address
+
+    Returns:
+      ``None``
+    """
+    jlink = context.jlink
+    jlink.rtt_start(int(block_address, 16))
+    while True:
+        try:
+            jlink.rtt_get_num_up_buffers()
+            jlink.rtt_get_num_down_buffers()
+            break
+        except pylink.errors.JLinkRTTException as e:
+            time.sleep(0.1)
+
+    assert jlink.rtt_get_num_up_buffers() > 0
+    assert jlink.rtt_get_num_down_buffers() > 0
+
+
+@behave.when('I write "{message}" to RTT channel {channel}')
+def step_write_rtt_channel(context, message, channel):
+    """Writes a message to an RTT channel.
+
+    Args:
+      context (Context): the ``Context`` instance
+      message (str): the message to write
+      channel (str): the RTT channel to write to
+
+    Returns:
+      ``None``
+    """
+    bytes_to_write = list(bytearray(message, 'utf-8') + b'\x0A\x00')
+    jlink = context.jlink
+    bytes_written = jlink.rtt_write(int(channel), bytes_to_write)
+    assert len(bytes_to_write) == bytes_written
+
+
+@behave.then('I should read "{message}" on RTT channel {channel}')
+def step_read_rtt_channel(context, message, channel):
+    """Checks that the expected message is read over the RTT channel.
+
+    Args:
+      context (Context): the ``Context`` instance
+      message (str): the expected message
+      channel (str): the RTT channel to read from
+
+    Returns:
+      ``None``
+    """
+    jlink = context.jlink
+    expected = str(message)
+
+    bytes_read = []
+    while len(bytes_read) < len(message):
+        bytes_read += jlink.rtt_read(int(channel), 1024)
+        time.sleep(0.1)
+
+    actual = ''.join(map(chr, bytes_read)).strip()
+    assert expected == actual

--- a/tests/functional/firmware/k21-rtt/Makefile
+++ b/tests/functional/firmware/k21-rtt/Makefile
@@ -1,0 +1,59 @@
+# Copyright 2016 Square, Inc.
+
+# Commands
+TARGET_PREFIX = arm-none-eabi-
+AS            = $(TARGET_PREFIX)as
+LD            = $(TARGET_PREFIX)ld
+CC            = $(TARGET_PREFIX)gcc
+CPP           = $(TARGET_PREFIX)g++
+OBJCOPY       = $(TARGET_PREFIX)objcopy
+CP            = cp
+MKDIR         = mkdir
+
+# Directories
+BUILDDIR      = build
+ASMDIR        = asm
+SRCDIR        = src
+VENDDIR       = vendor
+
+# Flags
+ASFLAGS       = -g -mthumb -mcpu=cortex-m4
+LDFLAGS       = -T$(ASMDIR)/gcc.ld --specs=nosys.specs -mthumb -mcpu=cortex-m4 -nostartfiles
+CCFLAGS       = -S -Wall -O0 -mcpu=cortex-m4 -mthumb -g -Ivendor
+
+# Output Files
+BIN           = $(BUILDDIR)/firmware.bin
+ELF           = $(BUILDDIR)/firmware.elf
+ASOURCES      = $(notdir $(wildcard $(ASMDIR)/*.s))
+CSOURCES      = $(notdir $(wildcard $(SRCDIR)/*.c)) $(notdir $(wildcard $(VENDDIR)/*.c))
+OBJS          = $(addprefix $(BUILDDIR)/,$(ASOURCES:.s=.o)) $(addprefix $(BUILDDIR)/,$(CSOURCES:.c=.o))
+
+.PHONY:	all clean
+
+all:	$(BIN)
+
+clean:
+	-$(RM) -rf $(BUILDDIR)
+
+$(ELF):	$(OBJS)
+	@$(MKDIR) -p $(BUILDDIR)
+	$(CC) $(LDFLAGS) -o $@ $^
+
+$(BUILDDIR)/%.o: $(BUILDDIR)/%.s
+	@$(MKDIR) -p $(BUILDDIR)
+	$(AS) $(ASFLAGS) -o $@ $<
+
+$(BUILDDIR)/%.s: $(ASMDIR)/%.s
+	@$(MKDIR) -p $(BUILDDIR)
+	$(CP) $< $(BUILDDIR)/
+
+$(BUILDDIR)/%.s: $(SRCDIR)/%.c
+	@$(MKDIR) -p $(BUILDDIR)
+	$(CC) $(CCFLAGS) -o $@ $<
+
+$(BUILDDIR)/%.s: $(VENDDIR)/%.c
+	@$(MKDIR) -p $(BUILDDIR)
+	$(CC) $(CCFLAGS) -o $@ $<
+
+%.bin:	%.elf
+	$(OBJCOPY) -O binary $< $@

--- a/tests/functional/firmware/k21-rtt/README.md
+++ b/tests/functional/firmware/k21-rtt/README.md
@@ -1,0 +1,20 @@
+# K21 RTT
+
+This firmware build demonstrates using Real-Time Transfer (RTT) to send and
+receive data on a K21.  This firmware is known to work on the `K21F120M`
+evaluation board.
+
+## Building the Firmware
+
+To build the firmware, run `make` from within the directory.  This will create
+a build directory containing the binary files.
+
+## Firmware Overview
+
+This firmware does the following things on boot:
+
+     1. Initializes the RTT control block.
+     2. Sets names for each of the 3 up and down buffers.
+     3. Reads a single character from RTT channel 0.
+     4. Writes the read character from step three to RTT channel 0.
+     5. Repeats again from step 3.

--- a/tests/functional/firmware/k21-rtt/asm/bootloader.s
+++ b/tests/functional/firmware/k21-rtt/asm/bootloader.s
@@ -1,0 +1,188 @@
+/* File: bootloader.s
+ * Purpose: bootstrap the firmware
+ * Date Modified: 13 September 2016
+ *
+ * Modified from the original `startup_ARMCM4.S` file.
+ * Original Version: V2.0
+ * Date Created: 16 August 2013
+ *
+/* Copyright (c) 2011 - 2013 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+	.syntax	unified
+	.arch	armv7e-m
+
+	WDOG_BASE_ADDR	= 0x40052000
+	WDOG_STCTRLH	= 0x00
+	WDOG_UNLOCK	= 0x0E
+
+        .section .stack
+        .align  3
+        .equ    Stack_Size, 1024
+        .globl  __StackTop
+        .globl  __StackLimit
+__StackLimit:
+        .space  Stack_Size
+        .size   __StackLimit, . - __StackLimit
+__StackTop:
+        .size   __StackTop, . - __StackTop
+
+#if 0
+        .section .heap
+        .align  3
+        .equ    Heap_Size, 1024
+        .globl  __HeapBase
+        .globl  __HeapLimit
+__HeapBase:
+        .space  Heap_Size
+        .size   __HeapBase, . - __HeapBase
+__HeapLimit:
+        .size   __HeapLimit, . - __HeapLimit
+#endif
+
+	.section .isr_vector
+	.align	2
+	.globl	__isr_vector
+__isr_vector:
+	.long	__StackTop            /* Top of Stack */
+	.long	Reset_Handler         /* Reset Handler */
+	.long	NMI_Handler           /* NMI Handler */
+	.long	HardFault_Handler     /* Hard Fault Handler */
+	.long	MemManage_Handler     /* MPU Fault Handler */
+	.long	BusFault_Handler      /* Bus Fault Handler */
+	.long	UsageFault_Handler    /* Usage Fault Handler */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	SVC_Handler           /* SVCall Handler */
+	.long	DebugMon_Handler      /* Debug Monitor Handler */
+	.long	0                     /* Reserved */
+	.long	PendSV_Handler        /* PendSV Handler */
+	.long	SysTick_Handler       /* SysTick Handler */
+
+	/* External interrupts */
+	.long	Default_Handler
+
+	.size	__isr_vector, . - __isr_vector
+
+	.section .fcf
+	.byte	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF	/* Backdoor Comparison Key */
+	.byte   0xFF, 0xFF, 0xFF, 0xFF				/* FPROT[3..0] */
+	.byte	0xFE						/* FSEC */
+	.byte	0x07						/* FOPT */
+	.byte	0xFF						/* FEPROT */
+	.byte	0xFF						/* FDPROT */
+
+	.text
+	.thumb
+	.thumb_func
+	.align	2
+	.globl	Reset_Handler
+	.type	Reset_Handler, %function
+Reset_Handler:
+	/* Unlock WDOG */
+	ldr	r0, =WDOG_BASE_ADDR
+	ldr	r1, =0xC520
+	strh	r1, [r0, WDOG_UNLOCK]
+	ldr	r1, =0xD928
+	strh	r1, [r0, WDOG_UNLOCK]
+
+	/* Disable WDOG */
+	ldrh	r1, [r0, WDOG_STCTRLH]
+	bic	r1, #1
+	strh	r1, [r0, WDOG_STCTRLH]
+
+/*     Loop to copy data from read only memory to RAM. The ranges
+ *      of copy from/to are specified by following symbols evaluated in
+ *      linker script.
+ *      __etext: End of code section, i.e., begin of data sections to copy from.
+ *      __data_start__/__data_end__: RAM address range that data should be
+ *      copied to. Both must be aligned to 4 bytes boundary.  */
+
+        ldr     r1, =__etext
+        ldr     r2, =__data_start__
+        ldr     r3, =__data_end__
+
+/* Here are two copies of loop implemenations. First one favors code size
+ * and the second one favors performance. Default uses the first one.
+ * Change to "#if 0" to use the second one */
+.flash_to_ram_loop:
+        cmp     r2, r3
+        ittt    lt
+        ldrlt   r0, [r1], #4
+        strlt   r0, [r2], #4
+        blt     .flash_to_ram_loop
+
+/* Clear .bss segment */
+        mov     r0, #0
+        ldr     r1, =__bss_start__
+        ldr     r2, =__bss_end__
+.clear_bss_loop:
+        cmp     r1, r2
+        itt     lt
+        strlt   r0, [r1], #4
+        blt     .clear_bss_loop
+
+/* Call libc init routines */
+/*        bl      __libc_init_array */
+
+/* Call main */
+        bl      main
+.exit_loop:
+        b       .exit_loop
+
+	.pool
+	.size	Reset_Handler, . - Reset_Handler
+
+	.align	1
+	.thumb_func
+	.weak	Default_Handler
+	.type	Default_Handler, %function
+Default_Handler:
+	b	.
+	.size	Default_Handler, . - Default_Handler
+
+/*    Macro to define default handlers. Default handler
+ *    will be weak symbol and just dead loops. They can be
+ *    overwritten by other handlers */
+	.macro	def_irq_handler	handler_name
+	.weak	\handler_name
+	.set	\handler_name, Default_Handler
+	.endm
+
+	def_irq_handler	NMI_Handler
+	def_irq_handler	HardFault_Handler
+	def_irq_handler	MemManage_Handler
+	def_irq_handler	BusFault_Handler
+	def_irq_handler	UsageFault_Handler
+	def_irq_handler	SVC_Handler
+	def_irq_handler	DebugMon_Handler
+	def_irq_handler	PendSV_Handler
+	def_irq_handler	SysTick_Handler
+	def_irq_handler	DEF_IRQHandler
+
+        .end

--- a/tests/functional/firmware/k21-rtt/asm/gcc.ld
+++ b/tests/functional/firmware/k21-rtt/asm/gcc.ld
@@ -1,0 +1,158 @@
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 512K
+  RAM (rwx)  : ORIGIN = 0x1FFF0000, LENGTH = 64K
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+	.text :
+	{
+		KEEP(*(.isr_vector))
+
+		/* Flash configuration field; woe be to the one who relocates
+		 * this section. Extremem care should be taken when modifying
+		 * this region.
+		 */
+		. = 0x400;
+		KEEP(*(.fcf))
+
+		*(.text*)
+
+		KEEP(*(.init))
+		KEEP(*(.fini))
+
+		/* .ctors */
+                *crtbegin.o(.ctors)
+                *crtbegin?.o(.ctors)
+                *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+                *(SORT(.ctors.*))
+                *(.ctors)
+
+		/* .dtors */
+                *crtbegin.o(.dtors)
+                *crtbegin?.o(.dtors)
+                *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+                *(SORT(.dtors.*))
+                *(.dtors)
+
+		*(.rodata*)
+
+		KEEP(*(.eh_frame*))
+	} > FLASH
+
+	.ARM.extab :
+	{
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} > FLASH
+
+	__exidx_start = .;
+	.ARM.exidx :
+	{
+		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
+	} > FLASH
+	__exidx_end = .;
+
+	__etext = .;
+
+	.data : AT (__etext)
+	{
+		__data_start__ = .;
+		*(vtable)
+		*(.data*)
+
+		. = ALIGN(4);
+		/* preinit data */
+		PROVIDE_HIDDEN (__preinit_array_start = .);
+		KEEP(*(.preinit_array))
+		PROVIDE_HIDDEN (__preinit_array_end = .);
+
+		. = ALIGN(4);
+		/* init data */
+		PROVIDE_HIDDEN (__init_array_start = .);
+		KEEP(*(SORT(.init_array.*)))
+		KEEP(*(.init_array))
+		PROVIDE_HIDDEN (__init_array_end = .);
+
+
+		. = ALIGN(4);
+		/* finit data */
+		PROVIDE_HIDDEN (__fini_array_start = .);
+		KEEP(*(SORT(.fini_array.*)))
+		KEEP(*(.fini_array))
+		PROVIDE_HIDDEN (__fini_array_end = .);
+
+		KEEP(*(.jcr*))
+		. = ALIGN(4);
+		/* All data end */
+		__data_end__ = .;
+
+	} > RAM
+
+	.bss :
+	{
+		. = ALIGN(4);
+		__bss_start__ = .;
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(4);
+		__bss_end__ = .;
+	} > RAM
+
+	.heap (COPY):
+	{
+		__end__ = .;
+		PROVIDE(end = .);
+		*(.heap*)
+		__HeapLimit = .;
+	} > RAM
+
+	/* .stack_dummy section doesn't contains any symbols. It is only
+	 * used for linker to calculate size of stack sections, and assign
+	 * values to stack symbols later */
+	.stack_dummy (COPY):
+	{
+		*(.stack*)
+	} > RAM
+
+	/* Set stack top to end of RAM, and stack limit move down by
+	 * size of stack_dummy section */
+	__StackTop = ORIGIN(RAM) + LENGTH(RAM);
+	__StackLimit = __StackTop - SIZEOF(.stack_dummy);
+	PROVIDE(__stack = __StackTop);
+
+	/* Check if data + heap + stack exceeds RAM limit */
+	ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/tests/functional/firmware/k21-rtt/src/main.c
+++ b/tests/functional/firmware/k21-rtt/src/main.c
@@ -1,0 +1,57 @@
+/******************************************************************************
+ * File: main.c
+ *
+ * Copyright (c) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Ford Peprah <ford@squareup.com>
+ *
+ * Created: March 12th, 2019
+ * Modified: March 12th, 2019
+ *****************************************************************************/
+
+#include <SEGGER_RTT.h>
+
+#include <string.h>
+
+#define FOREVER  for(;;)
+
+
+int main(void) {
+    char up_buf[2][1024] = {{0}};
+    char down_buf[2][1024] = {{0}};
+    char input;
+
+    SEGGER_RTT_Init();
+
+    // Up Buffer 0 is configured at compile-time; can only change name.
+    SEGGER_RTT_SetNameUpBuffer(0, "PuTTY");
+    SEGGER_RTT_ConfigUpBuffer(1, "RUMBA", up_buf[0], sizeof(up_buf[0]), 0x0);
+    SEGGER_RTT_ConfigUpBuffer(2, "ZOC", up_buf[1], sizeof(up_buf[1]), 0x0);
+
+    // Down Buffer 0 is configured at compile-time; can only change name.
+    SEGGER_RTT_SetNameDownBuffer(0, "iTerm2");
+    SEGGER_RTT_ConfigDownBuffer(1, "ZTerm", down_buf[0], sizeof(down_buf[0]), 0x0);
+    SEGGER_RTT_ConfigDownBuffer(2, "xterm", down_buf[1], sizeof(down_buf[1]), 0x0);
+
+    FOREVER {
+        input = (char)0;
+        while (!input) {
+            SEGGER_RTT_Read(0, &input, 1);
+        }
+        SEGGER_RTT_PutChar(0, input);
+    }
+
+    return 0;
+}

--- a/tests/functional/firmware/k21-rtt/vendor/SEGGER_RTT.c
+++ b/tests/functional/firmware/k21-rtt/vendor/SEGGER_RTT.c
@@ -1,0 +1,1761 @@
+/*********************************************************************
+*                    SEGGER Microcontroller GmbH                     *
+*                        The Embedded Experts                        *
+**********************************************************************
+*                                                                    *
+*            (c) 1995 - 2018 SEGGER Microcontroller GmbH             *
+*                                                                    *
+*       www.segger.com     Support: support@segger.com               *
+*                                                                    *
+**********************************************************************
+*                                                                    *
+*       SEGGER RTT * Real Time Transfer for embedded targets         *
+*                                                                    *
+**********************************************************************
+*                                                                    *
+* All rights reserved.                                               *
+*                                                                    *
+* SEGGER strongly recommends to not make any changes                 *
+* to or modify the source code of this software in order to stay     *
+* compatible with the RTT protocol and J-Link.                       *
+*                                                                    *
+* Redistribution and use in source and binary forms, with or         *
+* without modification, are permitted provided that the following    *
+* conditions are met:                                                *
+*                                                                    *
+* o Redistributions of source code must retain the above copyright   *
+*   notice, this list of conditions and the following disclaimer.    *
+*                                                                    *
+* o Redistributions in binary form must reproduce the above          *
+*   copyright notice, this list of conditions and the following      *
+*   disclaimer in the documentation and/or other materials provided  *
+*   with the distribution.                                           *
+*                                                                    *
+* o Neither the name of SEGGER Microcontroller GmbH                  *
+*   nor the names of its contributors may be used to endorse or      *
+*   promote products derived from this software without specific     *
+*   prior written permission.                                        *
+*                                                                    *
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND             *
+* CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,        *
+* INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF           *
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+* DISCLAIMED. IN NO EVENT SHALL SEGGER Microcontroller BE LIABLE FOR *
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR           *
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT  *
+* OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;    *
+* OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF      *
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT          *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE  *
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH   *
+* DAMAGE.                                                            *
+*                                                                    *
+**********************************************************************
+---------------------------END-OF-HEADER------------------------------
+File    : SEGGER_RTT.c
+Purpose : Implementation of SEGGER real-time transfer (RTT) which
+          allows real-time communication on targets which support
+          debugger memory accesses while the CPU is running.
+Revision: $Rev: 12804 $
+
+Additional information:
+          Type "int" is assumed to be 32-bits in size
+          H->T    Host to target communication
+          T->H    Target to host communication
+
+          RTT channel 0 is always present and reserved for Terminal usage.
+          Name is fixed to "Terminal"
+
+          Effective buffer size: SizeOfBuffer - 1
+
+          WrOff == RdOff:       Buffer is empty
+          WrOff == (RdOff - 1): Buffer is full
+          WrOff >  RdOff:       Free space includes wrap-around
+          WrOff <  RdOff:       Used space includes wrap-around
+          (WrOff == (SizeOfBuffer - 1)) && (RdOff == 0):
+                                Buffer full and wrap-around after next byte
+
+
+----------------------------------------------------------------------
+*/
+
+#include "SEGGER_RTT.h"
+
+#include <string.h>                 // for memcpy
+
+/*********************************************************************
+*
+*       Configuration, default values
+*
+**********************************************************************
+*/
+
+#ifndef   BUFFER_SIZE_UP
+  #define BUFFER_SIZE_UP                                  1024  // Size of the buffer for terminal output of target, up to host
+#endif
+
+#ifndef   BUFFER_SIZE_DOWN
+  #define BUFFER_SIZE_DOWN                                16    // Size of the buffer for terminal input to target from host (Usually keyboard input)
+#endif
+
+#ifndef   SEGGER_RTT_MAX_NUM_UP_BUFFERS
+  #define SEGGER_RTT_MAX_NUM_UP_BUFFERS                    2    // Number of up-buffers (T->H) available on this target
+#endif
+
+#ifndef   SEGGER_RTT_MAX_NUM_DOWN_BUFFERS
+  #define SEGGER_RTT_MAX_NUM_DOWN_BUFFERS                  2    // Number of down-buffers (H->T) available on this target
+#endif
+
+#ifndef SEGGER_RTT_BUFFER_SECTION
+  #if defined(SEGGER_RTT_SECTION)
+    #define SEGGER_RTT_BUFFER_SECTION SEGGER_RTT_SECTION
+  #endif
+#endif
+
+#ifndef   SEGGER_RTT_ALIGNMENT
+  #define SEGGER_RTT_ALIGNMENT                            0
+#endif
+
+#ifndef   SEGGER_RTT_BUFFER_ALIGNMENT
+  #define SEGGER_RTT_BUFFER_ALIGNMENT                     0
+#endif
+
+#ifndef   SEGGER_RTT_MODE_DEFAULT
+  #define SEGGER_RTT_MODE_DEFAULT                         SEGGER_RTT_MODE_NO_BLOCK_SKIP
+#endif
+
+#ifndef   SEGGER_RTT_LOCK
+  #define SEGGER_RTT_LOCK()
+#endif
+
+#ifndef   SEGGER_RTT_UNLOCK
+  #define SEGGER_RTT_UNLOCK()
+#endif
+
+#ifndef   STRLEN
+  #define STRLEN(a)                                       strlen((a))
+#endif
+
+#ifndef   SEGGER_RTT_MEMCPY_USE_BYTELOOP
+  #define SEGGER_RTT_MEMCPY_USE_BYTELOOP                  0
+#endif
+
+#ifndef   SEGGER_RTT_MEMCPY
+  #ifdef  MEMCPY
+    #define SEGGER_RTT_MEMCPY(pDest, pSrc, NumBytes)      MEMCPY((pDest), (pSrc), (NumBytes))
+  #else
+    #define SEGGER_RTT_MEMCPY(pDest, pSrc, NumBytes)      memcpy((pDest), (pSrc), (NumBytes))
+  #endif
+#endif
+
+#ifndef   MIN
+  #define MIN(a, b)         (((a) < (b)) ? (a) : (b))
+#endif
+
+#ifndef   MAX
+  #define MAX(a, b)         (((a) > (b)) ? (a) : (b))
+#endif
+//
+// For some environments, NULL may not be defined until certain headers are included
+//
+#ifndef NULL
+  #define NULL 0
+#endif
+
+/*********************************************************************
+*
+*       Defines, fixed
+*
+**********************************************************************
+*/
+#if (defined __ICCARM__) || (defined __ICCRX__)
+  #define RTT_PRAGMA(P) _Pragma(#P)
+#endif
+
+#if SEGGER_RTT_ALIGNMENT || SEGGER_RTT_BUFFER_ALIGNMENT
+  #if (defined __GNUC__)
+    #define SEGGER_RTT_ALIGN(Var, Alignment) Var __attribute__ ((aligned (Alignment)))
+  #elif (defined __ICCARM__) || (defined __ICCRX__)
+    #define PRAGMA(A) _Pragma(#A)
+#define SEGGER_RTT_ALIGN(Var, Alignment) RTT_PRAGMA(data_alignment=Alignment) \
+                                  Var
+  #elif (defined __CC_ARM)
+    #define SEGGER_RTT_ALIGN(Var, Alignment) Var __attribute__ ((aligned (Alignment)))
+  #else
+    #error "Alignment not supported for this compiler."
+  #endif
+#else
+  #define SEGGER_RTT_ALIGN(Var, Alignment) Var
+#endif
+
+#if defined(SEGGER_RTT_SECTION) || defined (SEGGER_RTT_BUFFER_SECTION)
+  #if (defined __GNUC__)
+    #define SEGGER_RTT_PUT_SECTION(Var, Section) __attribute__ ((section (Section))) Var
+  #elif (defined __ICCARM__) || (defined __ICCRX__)
+#define SEGGER_RTT_PUT_SECTION(Var, Section) RTT_PRAGMA(location=Section) \
+                                        Var
+  #elif (defined __CC_ARM)
+    #define SEGGER_RTT_PUT_SECTION(Var, Section) __attribute__ ((section (Section), zero_init))  Var
+  #else
+    #error "Section placement not supported for this compiler."
+  #endif
+#else
+  #define SEGGER_RTT_PUT_SECTION(Var, Section) Var
+#endif
+
+
+#if SEGGER_RTT_ALIGNMENT
+  #define SEGGER_RTT_CB_ALIGN(Var)  SEGGER_RTT_ALIGN(Var, SEGGER_RTT_ALIGNMENT)
+#else
+  #define SEGGER_RTT_CB_ALIGN(Var)  Var
+#endif
+
+#if SEGGER_RTT_BUFFER_ALIGNMENT
+  #define SEGGER_RTT_BUFFER_ALIGN(Var)  SEGGER_RTT_ALIGN(Var, SEGGER_RTT_BUFFER_ALIGNMENT)
+#else
+  #define SEGGER_RTT_BUFFER_ALIGN(Var)  Var
+#endif
+
+
+#if defined(SEGGER_RTT_SECTION)
+  #define SEGGER_RTT_PUT_CB_SECTION(Var) SEGGER_RTT_PUT_SECTION(Var, SEGGER_RTT_SECTION)
+#else
+  #define SEGGER_RTT_PUT_CB_SECTION(Var) Var
+#endif
+
+#if defined(SEGGER_RTT_BUFFER_SECTION)
+  #define SEGGER_RTT_PUT_BUFFER_SECTION(Var) SEGGER_RTT_PUT_SECTION(Var, SEGGER_RTT_BUFFER_SECTION)
+#else
+  #define SEGGER_RTT_PUT_BUFFER_SECTION(Var) Var
+#endif
+
+/*********************************************************************
+*
+*       Static const data
+*
+**********************************************************************
+*/
+
+static unsigned char _aTerminalId[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+
+/*********************************************************************
+*
+*       Static data
+*
+**********************************************************************
+*/
+//
+// RTT Control Block and allocate buffers for channel 0
+//
+SEGGER_RTT_PUT_CB_SECTION(SEGGER_RTT_CB_ALIGN(SEGGER_RTT_CB _SEGGER_RTT));
+
+SEGGER_RTT_PUT_BUFFER_SECTION(SEGGER_RTT_BUFFER_ALIGN(static char _acUpBuffer  [BUFFER_SIZE_UP]));
+SEGGER_RTT_PUT_BUFFER_SECTION(SEGGER_RTT_BUFFER_ALIGN(static char _acDownBuffer[BUFFER_SIZE_DOWN]));
+
+static char _ActiveTerminal;
+
+/*********************************************************************
+*
+*       Static functions
+*
+**********************************************************************
+*/
+
+/*********************************************************************
+*
+*       _DoInit()
+*
+*  Function description
+*    Initializes the control block an buffers.
+*    May only be called via INIT() to avoid overriding settings.
+*
+*/
+#define INIT()  do {                                            \
+                  if (_SEGGER_RTT.acID[0] == '\0') { _DoInit(); }  \
+                } while (0)
+static void _DoInit(void) {
+  SEGGER_RTT_CB* p;
+  //
+  // Initialize control block
+  //
+  p = &_SEGGER_RTT;
+  p->MaxNumUpBuffers    = SEGGER_RTT_MAX_NUM_UP_BUFFERS;
+  p->MaxNumDownBuffers  = SEGGER_RTT_MAX_NUM_DOWN_BUFFERS;
+  //
+  // Initialize up buffer 0
+  //
+  p->aUp[0].sName         = "Terminal";
+  p->aUp[0].pBuffer       = _acUpBuffer;
+  p->aUp[0].SizeOfBuffer  = sizeof(_acUpBuffer);
+  p->aUp[0].RdOff         = 0u;
+  p->aUp[0].WrOff         = 0u;
+  p->aUp[0].Flags         = SEGGER_RTT_MODE_DEFAULT;
+  //
+  // Initialize down buffer 0
+  //
+  p->aDown[0].sName         = "Terminal";
+  p->aDown[0].pBuffer       = _acDownBuffer;
+  p->aDown[0].SizeOfBuffer  = sizeof(_acDownBuffer);
+  p->aDown[0].RdOff         = 0u;
+  p->aDown[0].WrOff         = 0u;
+  p->aDown[0].Flags         = SEGGER_RTT_MODE_DEFAULT;
+  //
+  // Finish initialization of the control block.
+  // Copy Id string in three steps to make sure "SEGGER RTT" is not found
+  // in initializer memory (usually flash) by J-Link
+  //
+  strcpy(&p->acID[7], "RTT");
+  strcpy(&p->acID[0], "SEGGER");
+  p->acID[6] = ' ';
+}
+
+/*********************************************************************
+*
+*       _WriteBlocking()
+*
+*  Function description
+*    Stores a specified number of characters in SEGGER RTT ring buffer
+*    and updates the associated write pointer which is periodically
+*    read by the host.
+*    The caller is responsible for managing the write chunk sizes as
+*    _WriteBlocking() will block until all data has been posted successfully.
+*
+*  Parameters
+*    pRing        Ring buffer to post to.
+*    pBuffer      Pointer to character array. Does not need to point to a \0 terminated string.
+*    NumBytes     Number of bytes to be stored in the SEGGER RTT control block.
+*
+*  Return value
+*    >= 0 - Number of bytes written into buffer.
+*/
+static unsigned _WriteBlocking(SEGGER_RTT_BUFFER_UP* pRing, const char* pBuffer, unsigned NumBytes) {
+  unsigned NumBytesToWrite;
+  unsigned NumBytesWritten;
+  unsigned RdOff;
+  unsigned WrOff;
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+  char*    pDst;
+#endif
+  //
+  // Write data to buffer and handle wrap-around if necessary
+  //
+  NumBytesWritten = 0u;
+  WrOff = pRing->WrOff;
+  do {
+    RdOff = pRing->RdOff;                         // May be changed by host (debug probe) in the meantime
+    if (RdOff > WrOff) {
+      NumBytesToWrite = RdOff - WrOff - 1u;
+    } else {
+      NumBytesToWrite = pRing->SizeOfBuffer - (WrOff - RdOff + 1u);
+    }
+    NumBytesToWrite = MIN(NumBytesToWrite, (pRing->SizeOfBuffer - WrOff));      // Number of bytes that can be written until buffer wrap-around
+    NumBytesToWrite = MIN(NumBytesToWrite, NumBytes);
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+    pDst = pRing->pBuffer + WrOff;
+    NumBytesWritten += NumBytesToWrite;
+    NumBytes        -= NumBytesToWrite;
+    WrOff           += NumBytesToWrite;
+    while (NumBytesToWrite--) {
+      *pDst++ = *pBuffer++;
+    };
+#else
+    SEGGER_RTT_MEMCPY(pRing->pBuffer + WrOff, pBuffer, NumBytesToWrite);
+    NumBytesWritten += NumBytesToWrite;
+    pBuffer         += NumBytesToWrite;
+    NumBytes        -= NumBytesToWrite;
+    WrOff           += NumBytesToWrite;
+#endif
+    if (WrOff == pRing->SizeOfBuffer) {
+      WrOff = 0u;
+    }
+    pRing->WrOff = WrOff;
+  } while (NumBytes);
+  //
+  return NumBytesWritten;
+}
+
+/*********************************************************************
+*
+*       _WriteNoCheck()
+*
+*  Function description
+*    Stores a specified number of characters in SEGGER RTT ring buffer
+*    and updates the associated write pointer which is periodically
+*    read by the host.
+*    It is callers responsibility to make sure data actually fits in buffer.
+*
+*  Parameters
+*    pRing        Ring buffer to post to.
+*    pBuffer      Pointer to character array. Does not need to point to a \0 terminated string.
+*    NumBytes     Number of bytes to be stored in the SEGGER RTT control block.
+*
+*  Notes
+*    (1) If there might not be enough space in the "Up"-buffer, call _WriteBlocking
+*/
+static void _WriteNoCheck(SEGGER_RTT_BUFFER_UP* pRing, const char* pData, unsigned NumBytes) {
+  unsigned NumBytesAtOnce;
+  unsigned WrOff;
+  unsigned Rem;
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+  char*    pDst;
+#endif
+
+  WrOff = pRing->WrOff;
+  Rem = pRing->SizeOfBuffer - WrOff;
+  if (Rem > NumBytes) {
+    //
+    // All data fits before wrap around
+    //
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+    pDst = pRing->pBuffer + WrOff;
+    WrOff += NumBytes;
+    while (NumBytes--) {
+      *pDst++ = *pData++;
+    };
+    pRing->WrOff = WrOff;
+#else
+    SEGGER_RTT_MEMCPY(pRing->pBuffer + WrOff, pData, NumBytes);
+    pRing->WrOff = WrOff + NumBytes;
+#endif
+  } else {
+    //
+    // We reach the end of the buffer, so need to wrap around
+    //
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+    pDst = pRing->pBuffer + WrOff;
+    NumBytesAtOnce = Rem;
+    while (NumBytesAtOnce--) {
+      *pDst++ = *pData++;
+    };
+    pDst = pRing->pBuffer;
+    NumBytesAtOnce = NumBytes - Rem;
+    while (NumBytesAtOnce--) {
+      *pDst++ = *pData++;
+    };
+    pRing->WrOff = NumBytes - Rem;
+#else
+    NumBytesAtOnce = Rem;
+    SEGGER_RTT_MEMCPY(pRing->pBuffer + WrOff, pData, NumBytesAtOnce);
+    NumBytesAtOnce = NumBytes - Rem;
+    SEGGER_RTT_MEMCPY(pRing->pBuffer, pData + Rem, NumBytesAtOnce);
+    pRing->WrOff = NumBytesAtOnce;
+#endif
+  }
+}
+
+/*********************************************************************
+*
+*       _PostTerminalSwitch()
+*
+*  Function description
+*    Switch terminal to the given terminal ID.  It is the caller's
+*    responsibility to ensure the terminal ID is correct and there is
+*    enough space in the buffer for this to complete successfully.
+*
+*  Parameters
+*    pRing        Ring buffer to post to.
+*    TerminalId   Terminal ID to switch to.
+*/
+static void _PostTerminalSwitch(SEGGER_RTT_BUFFER_UP* pRing, unsigned char TerminalId) {
+  unsigned char ac[2];
+
+  ac[0] = 0xFFu;
+  ac[1] = _aTerminalId[TerminalId];  // Caller made already sure that TerminalId does not exceed our terminal limit
+  _WriteBlocking(pRing, (const char*)ac, 2u);
+}
+
+/*********************************************************************
+*
+*       _GetAvailWriteSpace()
+*
+*  Function description
+*    Returns the number of bytes that can be written to the ring
+*    buffer without blocking.
+*
+*  Parameters
+*    pRing        Ring buffer to check.
+*
+*  Return value
+*    Number of bytes that are free in the buffer.
+*/
+static unsigned _GetAvailWriteSpace(SEGGER_RTT_BUFFER_UP* pRing) {
+  unsigned RdOff;
+  unsigned WrOff;
+  unsigned r;
+  //
+  // Avoid warnings regarding volatile access order.  It's not a problem
+  // in this case, but dampen compiler enthusiasm.
+  //
+  RdOff = pRing->RdOff;
+  WrOff = pRing->WrOff;
+  if (RdOff <= WrOff) {
+    r = pRing->SizeOfBuffer - 1u - WrOff + RdOff;
+  } else {
+    r = RdOff - WrOff - 1u;
+  }
+  return r;
+}
+
+/*********************************************************************
+*
+*       Public code
+*
+**********************************************************************
+*/
+/*********************************************************************
+*
+*       SEGGER_RTT_ReadNoLock()
+*
+*  Function description
+*    Reads characters from SEGGER real-time-terminal control block
+*    which have been previously stored by the host.
+*    Do not lock against interrupts and multiple access.
+*
+*  Parameters
+*    BufferIndex  Index of Down-buffer to be used (e.g. 0 for "Terminal").
+*    pBuffer      Pointer to buffer provided by target application, to copy characters from RTT-down-buffer to.
+*    BufferSize   Size of the target application buffer.
+*
+*  Return value
+*    Number of bytes that have been read.
+*/
+unsigned SEGGER_RTT_ReadNoLock(unsigned BufferIndex, void* pData, unsigned BufferSize) {
+  unsigned                NumBytesRem;
+  unsigned                NumBytesRead;
+  unsigned                RdOff;
+  unsigned                WrOff;
+  unsigned char*          pBuffer;
+  SEGGER_RTT_BUFFER_DOWN* pRing;
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+  const char*             pSrc;
+#endif
+  //
+  INIT();
+  pRing = &_SEGGER_RTT.aDown[BufferIndex];
+  pBuffer = (unsigned char*)pData;
+  RdOff = pRing->RdOff;
+  WrOff = pRing->WrOff;
+  NumBytesRead = 0u;
+  //
+  // Read from current read position to wrap-around of buffer, first
+  //
+  if (RdOff > WrOff) {
+    NumBytesRem = pRing->SizeOfBuffer - RdOff;
+    NumBytesRem = MIN(NumBytesRem, BufferSize);
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+    pSrc = pRing->pBuffer + RdOff;
+    NumBytesRead += NumBytesRem;
+    BufferSize   -= NumBytesRem;
+    RdOff        += NumBytesRem;
+    while (NumBytesRem--) {
+      *pBuffer++ = *pSrc++;
+    };
+#else
+    SEGGER_RTT_MEMCPY(pBuffer, pRing->pBuffer + RdOff, NumBytesRem);
+    NumBytesRead += NumBytesRem;
+    pBuffer      += NumBytesRem;
+    BufferSize   -= NumBytesRem;
+    RdOff        += NumBytesRem;
+#endif
+    //
+    // Handle wrap-around of buffer
+    //
+    if (RdOff == pRing->SizeOfBuffer) {
+      RdOff = 0u;
+    }
+  }
+  //
+  // Read remaining items of buffer
+  //
+  NumBytesRem = WrOff - RdOff;
+  NumBytesRem = MIN(NumBytesRem, BufferSize);
+  if (NumBytesRem > 0u) {
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+    pSrc = pRing->pBuffer + RdOff;
+    NumBytesRead += NumBytesRem;
+    BufferSize   -= NumBytesRem;
+    RdOff        += NumBytesRem;
+    while (NumBytesRem--) {
+      *pBuffer++ = *pSrc++;
+    };
+#else
+    SEGGER_RTT_MEMCPY(pBuffer, pRing->pBuffer + RdOff, NumBytesRem);
+    NumBytesRead += NumBytesRem;
+    pBuffer      += NumBytesRem;
+    BufferSize   -= NumBytesRem;
+    RdOff        += NumBytesRem;
+#endif
+  }
+  if (NumBytesRead) {
+    pRing->RdOff = RdOff;
+  }
+  //
+  return NumBytesRead;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_Read
+*
+*  Function description
+*    Reads characters from SEGGER real-time-terminal control block
+*    which have been previously stored by the host.
+*
+*  Parameters
+*    BufferIndex  Index of Down-buffer to be used (e.g. 0 for "Terminal").
+*    pBuffer      Pointer to buffer provided by target application, to copy characters from RTT-down-buffer to.
+*    BufferSize   Size of the target application buffer.
+*
+*  Return value
+*    Number of bytes that have been read.
+*/
+unsigned SEGGER_RTT_Read(unsigned BufferIndex, void* pBuffer, unsigned BufferSize) {
+  unsigned NumBytesRead;
+  //
+  SEGGER_RTT_LOCK();
+  //
+  // Call the non-locking read function
+  //
+  NumBytesRead = SEGGER_RTT_ReadNoLock(BufferIndex, pBuffer, BufferSize);
+  //
+  // Finish up.
+  //
+  SEGGER_RTT_UNLOCK();
+  //
+  return NumBytesRead;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_WriteWithOverwriteNoLock
+*
+*  Function description
+*    Stores a specified number of characters in SEGGER RTT
+*    control block.
+*    SEGGER_RTT_WriteWithOverwriteNoLock does not lock the application
+*    and overwrites data if the data does not fit into the buffer.
+*
+*  Parameters
+*    BufferIndex  Index of "Up"-buffer to be used (e.g. 0 for "Terminal").
+*    pBuffer      Pointer to character array. Does not need to point to a \0 terminated string.
+*    NumBytes     Number of bytes to be stored in the SEGGER RTT control block.
+*
+*  Notes
+*    (1) If there is not enough space in the "Up"-buffer, data is overwritten.
+*    (2) For performance reasons this function does not call Init()
+*        and may only be called after RTT has been initialized.
+*        Either by calling SEGGER_RTT_Init() or calling another RTT API function first.
+*    (3) Do not use SEGGER_RTT_WriteWithOverwriteNoLock if a J-Link
+*        connection reads RTT data.
+*/
+void SEGGER_RTT_WriteWithOverwriteNoLock(unsigned BufferIndex, const void* pBuffer, unsigned NumBytes) {
+  const char*           pData;
+  SEGGER_RTT_BUFFER_UP* pRing;
+  unsigned              Avail;
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+  char*                 pDst;
+#endif
+
+  pData = (const char *)pBuffer;
+  //
+  // Get "to-host" ring buffer and copy some elements into local variables.
+  //
+  pRing = &_SEGGER_RTT.aUp[BufferIndex];
+  //
+  // Check if we will overwrite data and need to adjust the RdOff.
+  //
+  if (pRing->WrOff == pRing->RdOff) {
+    Avail = pRing->SizeOfBuffer - 1u;
+  } else if ( pRing->WrOff < pRing->RdOff) {
+    Avail = pRing->RdOff - pRing->WrOff - 1u;
+  } else {
+    Avail = pRing->RdOff - pRing->WrOff - 1u + pRing->SizeOfBuffer;
+  }
+  if (NumBytes > Avail) {
+    pRing->RdOff += (NumBytes - Avail);
+    while (pRing->RdOff >= pRing->SizeOfBuffer) {
+      pRing->RdOff -= pRing->SizeOfBuffer;
+    }
+  }
+  //
+  // Write all data, no need to check the RdOff, but possibly handle multiple wrap-arounds
+  //
+  Avail = pRing->SizeOfBuffer - pRing->WrOff;
+  do {
+    if (Avail > NumBytes) {
+      //
+      // Last round
+      //
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+      pDst = pRing->pBuffer + pRing->WrOff;
+      Avail = NumBytes;
+      while (NumBytes--) {
+        *pDst++ = *pData++;
+      };
+      pRing->WrOff += Avail;
+#else
+      SEGGER_RTT_MEMCPY(pRing->pBuffer + pRing->WrOff, pData, NumBytes);
+      pRing->WrOff += NumBytes;
+#endif
+      break;
+    } else {
+      //
+      //  Wrap-around necessary, write until wrap-around and reset WrOff
+      //
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+      pDst = pRing->pBuffer + pRing->WrOff;
+      NumBytes -= Avail;
+      while (Avail--) {
+        *pDst++ = *pData++;
+      };
+      pRing->WrOff = 0;
+#else
+      SEGGER_RTT_MEMCPY(pRing->pBuffer + pRing->WrOff, pData, Avail);
+      pData += Avail;
+      pRing->WrOff = 0;
+      NumBytes -= Avail;
+#endif
+      Avail = (pRing->SizeOfBuffer - 1);
+    }
+  } while (NumBytes);
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_WriteSkipNoLock
+*
+*  Function description
+*    Stores a specified number of characters in SEGGER RTT
+*    control block which is then read by the host.
+*    SEGGER_RTT_WriteSkipNoLock does not lock the application and
+*    skips all data, if the data does not fit into the buffer.
+*
+*  Parameters
+*    BufferIndex  Index of "Up"-buffer to be used (e.g. 0 for "Terminal").
+*    pBuffer      Pointer to character array. Does not need to point to a \0 terminated string.
+*    NumBytes     Number of bytes to be stored in the SEGGER RTT control block.
+*
+*  Return value
+*    Number of bytes which have been stored in the "Up"-buffer.
+*
+*  Notes
+*    (1) If there is not enough space in the "Up"-buffer, all data is dropped.
+*    (2) For performance reasons this function does not call Init()
+*        and may only be called after RTT has been initialized.
+*        Either by calling SEGGER_RTT_Init() or calling another RTT API function first.
+*/
+unsigned SEGGER_RTT_WriteSkipNoLock(unsigned BufferIndex, const void* pBuffer, unsigned NumBytes) {
+  const char*           pData;
+  SEGGER_RTT_BUFFER_UP* pRing;
+  unsigned              Avail;
+  unsigned              RdOff;
+  unsigned              WrOff;
+  unsigned              Rem;
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+  char*                 pDst;
+#endif
+
+  pData = (const char *)pBuffer;
+  //
+  // Get "to-host" ring buffer and copy some elements into local variables.
+  //
+  pRing = &_SEGGER_RTT.aUp[BufferIndex];
+  RdOff = pRing->RdOff;
+  WrOff = pRing->WrOff;
+  //
+  // Handle the most common cases fastest.
+  // Which is:
+  //    RdOff <= WrOff -> Space until wrap around is free.
+  //  AND
+  //    WrOff + NumBytes < SizeOfBuffer -> No Wrap around necessary.
+  //
+  //  OR
+  //
+  //    RdOff > WrOff -> Space until RdOff - 1 is free.
+  //  AND
+  //    WrOff + NumBytes < RdOff -> Data fits into buffer
+  //
+  if (RdOff <= WrOff) {
+    //
+    // Get space until WrOff will be at wrap around.
+    //
+    Avail = pRing->SizeOfBuffer - 1u - WrOff ;
+    if (Avail >= NumBytes) {
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+      pDst = pRing->pBuffer + WrOff;
+      WrOff += NumBytes;
+      while (NumBytes--) {
+        *pDst++ = *pData++;
+      };
+      pRing->WrOff = WrOff;
+#else
+      SEGGER_RTT_MEMCPY(pRing->pBuffer + WrOff, pData, NumBytes);
+      pRing->WrOff = WrOff + NumBytes;
+#endif
+      return 1;
+    }
+    //
+    // If data did not fit into space until wrap around calculate complete space in buffer.
+    //
+    Avail += RdOff;
+    //
+    // If there is still no space for the whole of this output, don't bother.
+    //
+    if (Avail >= NumBytes) {
+      //
+      //  OK, we have enough space in buffer. Copy in one or 2 chunks
+      //
+      Rem = pRing->SizeOfBuffer - WrOff;      // Space until end of buffer
+      if (Rem > NumBytes) {
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+        pDst = pRing->pBuffer + WrOff;
+        WrOff += NumBytes;
+        while (NumBytes--) {
+          *pDst++ = *pData++;
+        };
+        pRing->WrOff = WrOff;
+#else
+        SEGGER_RTT_MEMCPY(pRing->pBuffer + WrOff, pData, NumBytes);
+        pRing->WrOff = WrOff + NumBytes;
+#endif
+      } else {
+        //
+        // We reach the end of the buffer, so need to wrap around
+        //
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+        pDst = pRing->pBuffer + WrOff;
+        NumBytes -= Rem;
+        WrOff = NumBytes;
+        do {
+          *pDst++ = *pData++;
+        } while (--Rem);
+        pDst = pRing->pBuffer;
+        while (NumBytes--) {
+          *pDst++ = *pData++;
+        };
+        pRing->WrOff = WrOff;
+#else
+        SEGGER_RTT_MEMCPY(pRing->pBuffer + WrOff, pData, Rem);
+        SEGGER_RTT_MEMCPY(pRing->pBuffer, pData + Rem, NumBytes - Rem);
+        pRing->WrOff = NumBytes - Rem;
+#endif
+      }
+      return 1;
+    }
+  } else {
+    Avail = RdOff - WrOff - 1u;
+    if (Avail >= NumBytes) {
+#if SEGGER_RTT_MEMCPY_USE_BYTELOOP
+      pDst = pRing->pBuffer + WrOff;
+      WrOff += NumBytes;
+      while (NumBytes--) {
+        *pDst++ = *pData++;
+      };
+      pRing->WrOff = WrOff;
+#else
+      SEGGER_RTT_MEMCPY(pRing->pBuffer + WrOff, pData, NumBytes);
+      pRing->WrOff = WrOff + NumBytes;
+#endif
+      return 1;
+    }
+  }
+  //
+  // If we reach this point no data has been written
+  //
+  return 0;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_WriteNoLock
+*
+*  Function description
+*    Stores a specified number of characters in SEGGER RTT
+*    control block which is then read by the host.
+*    SEGGER_RTT_WriteNoLock does not lock the application.
+*
+*  Parameters
+*    BufferIndex  Index of "Up"-buffer to be used (e.g. 0 for "Terminal").
+*    pBuffer      Pointer to character array. Does not need to point to a \0 terminated string.
+*    NumBytes     Number of bytes to be stored in the SEGGER RTT control block.
+*
+*  Return value
+*    Number of bytes which have been stored in the "Up"-buffer.
+*
+*  Notes
+*    (1) Data is stored according to buffer flags.
+*    (2) For performance reasons this function does not call Init()
+*        and may only be called after RTT has been initialized.
+*        Either by calling SEGGER_RTT_Init() or calling another RTT API function first.
+*/
+unsigned SEGGER_RTT_WriteNoLock(unsigned BufferIndex, const void* pBuffer, unsigned NumBytes) {
+  unsigned              Status;
+  unsigned              Avail;
+  const char*           pData;
+  SEGGER_RTT_BUFFER_UP* pRing;
+
+  pData = (const char *)pBuffer;
+  //
+  // Get "to-host" ring buffer.
+  //
+  pRing = &_SEGGER_RTT.aUp[BufferIndex];
+  //
+  // How we output depends upon the mode...
+  //
+  switch (pRing->Flags) {
+  case SEGGER_RTT_MODE_NO_BLOCK_SKIP:
+    //
+    // If we are in skip mode and there is no space for the whole
+    // of this output, don't bother.
+    //
+    Avail = _GetAvailWriteSpace(pRing);
+    if (Avail < NumBytes) {
+      Status = 0u;
+    } else {
+      Status = NumBytes;
+      _WriteNoCheck(pRing, pData, NumBytes);
+    }
+    break;
+  case SEGGER_RTT_MODE_NO_BLOCK_TRIM:
+    //
+    // If we are in trim mode, trim to what we can output without blocking.
+    //
+    Avail = _GetAvailWriteSpace(pRing);
+    Status = Avail < NumBytes ? Avail : NumBytes;
+    _WriteNoCheck(pRing, pData, Status);
+    break;
+  case SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL:
+    //
+    // If we are in blocking mode, output everything.
+    //
+    Status = _WriteBlocking(pRing, pData, NumBytes);
+    break;
+  default:
+    Status = 0u;
+    break;
+  }
+  //
+  // Finish up.
+  //
+  return Status;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_Write
+*
+*  Function description
+*    Stores a specified number of characters in SEGGER RTT
+*    control block which is then read by the host.
+*
+*  Parameters
+*    BufferIndex  Index of "Up"-buffer to be used (e.g. 0 for "Terminal").
+*    pBuffer      Pointer to character array. Does not need to point to a \0 terminated string.
+*    NumBytes     Number of bytes to be stored in the SEGGER RTT control block.
+*
+*  Return value
+*    Number of bytes which have been stored in the "Up"-buffer.
+*
+*  Notes
+*    (1) Data is stored according to buffer flags.
+*/
+unsigned SEGGER_RTT_Write(unsigned BufferIndex, const void* pBuffer, unsigned NumBytes) {
+  unsigned Status;
+  //
+  INIT();
+  SEGGER_RTT_LOCK();
+  //
+  // Call the non-locking write function
+  //
+  Status = SEGGER_RTT_WriteNoLock(BufferIndex, pBuffer, NumBytes);
+  //
+  // Finish up.
+  //
+  SEGGER_RTT_UNLOCK();
+  //
+  return Status;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_WriteString
+*
+*  Function description
+*    Stores string in SEGGER RTT control block.
+*    This data is read by the host.
+*
+*  Parameters
+*    BufferIndex  Index of "Up"-buffer to be used (e.g. 0 for "Terminal").
+*    s            Pointer to string.
+*
+*  Return value
+*    Number of bytes which have been stored in the "Up"-buffer.
+*
+*  Notes
+*    (1) Data is stored according to buffer flags.
+*    (2) String passed to this function has to be \0 terminated
+*    (3) \0 termination character is *not* stored in RTT buffer
+*/
+unsigned SEGGER_RTT_WriteString(unsigned BufferIndex, const char* s) {
+  unsigned Len;
+
+  Len = STRLEN(s);
+  return SEGGER_RTT_Write(BufferIndex, s, Len);
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_PutCharSkipNoLock
+*
+*  Function description
+*    Stores a single character/byte in SEGGER RTT buffer.
+*    SEGGER_RTT_PutCharSkipNoLock does not lock the application and
+*    skips the byte, if it does not fit into the buffer.
+*
+*  Parameters
+*    BufferIndex  Index of "Up"-buffer to be used (e.g. 0 for "Terminal").
+*    c            Byte to be stored.
+*
+*  Return value
+*    Number of bytes which have been stored in the "Up"-buffer.
+*
+*  Notes
+*    (1) If there is not enough space in the "Up"-buffer, the character is dropped.
+*    (2) For performance reasons this function does not call Init()
+*        and may only be called after RTT has been initialized.
+*        Either by calling SEGGER_RTT_Init() or calling another RTT API function first.
+*/
+
+unsigned SEGGER_RTT_PutCharSkipNoLock(unsigned BufferIndex, char c) {
+  SEGGER_RTT_BUFFER_UP* pRing;
+  unsigned              WrOff;
+  unsigned              Status;
+  //
+  // Get "to-host" ring buffer.
+  //
+  pRing = &_SEGGER_RTT.aUp[BufferIndex];
+  //
+  // Get write position and handle wrap-around if necessary
+  //
+  WrOff = pRing->WrOff + 1;
+  if (WrOff == pRing->SizeOfBuffer) {
+    WrOff = 0;
+  }
+  //
+  // Output byte if free space is available
+  //
+  if (WrOff != pRing->RdOff) {
+    pRing->pBuffer[pRing->WrOff] = c;
+    pRing->WrOff = WrOff;
+    Status = 1;
+  } else {
+    Status = 0;
+  }
+  //
+  return Status;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_PutCharSkip
+*
+*  Function description
+*    Stores a single character/byte in SEGGER RTT buffer.
+*
+*  Parameters
+*    BufferIndex  Index of "Up"-buffer to be used (e.g. 0 for "Terminal").
+*    c            Byte to be stored.
+*
+*  Return value
+*    Number of bytes which have been stored in the "Up"-buffer.
+*
+*  Notes
+*    (1) If there is not enough space in the "Up"-buffer, the character is dropped.
+*/
+
+unsigned SEGGER_RTT_PutCharSkip(unsigned BufferIndex, char c) {
+  SEGGER_RTT_BUFFER_UP* pRing;
+  unsigned              WrOff;
+  unsigned              Status;
+  //
+  // Prepare
+  //
+  INIT();
+  SEGGER_RTT_LOCK();
+  //
+  // Get "to-host" ring buffer.
+  //
+  pRing = &_SEGGER_RTT.aUp[BufferIndex];
+  //
+  // Get write position and handle wrap-around if necessary
+  //
+  WrOff = pRing->WrOff + 1;
+  if (WrOff == pRing->SizeOfBuffer) {
+    WrOff = 0;
+  }
+  //
+  // Output byte if free space is available
+  //
+  if (WrOff != pRing->RdOff) {
+    pRing->pBuffer[pRing->WrOff] = c;
+    pRing->WrOff = WrOff;
+    Status = 1;
+  } else {
+    Status = 0;
+  }
+  //
+  // Finish up.
+  //
+  SEGGER_RTT_UNLOCK();
+  //
+  return Status;
+}
+
+ /*********************************************************************
+*
+*       SEGGER_RTT_PutChar
+*
+*  Function description
+*    Stores a single character/byte in SEGGER RTT buffer.
+*
+*  Parameters
+*    BufferIndex  Index of "Up"-buffer to be used (e.g. 0 for "Terminal").
+*    c            Byte to be stored.
+*
+*  Return value
+*    Number of bytes which have been stored in the "Up"-buffer.
+*
+*  Notes
+*    (1) Data is stored according to buffer flags.
+*/
+
+unsigned SEGGER_RTT_PutChar(unsigned BufferIndex, char c) {
+  SEGGER_RTT_BUFFER_UP* pRing;
+  unsigned              WrOff;
+  unsigned              Status;
+  //
+  // Prepare
+  //
+  INIT();
+  SEGGER_RTT_LOCK();
+  //
+  // Get "to-host" ring buffer.
+  //
+  pRing = &_SEGGER_RTT.aUp[BufferIndex];
+  //
+  // Get write position and handle wrap-around if necessary
+  //
+  WrOff = pRing->WrOff + 1;
+  if (WrOff == pRing->SizeOfBuffer) {
+    WrOff = 0;
+  }
+  //
+  // Wait for free space if mode is set to blocking
+  //
+  if (pRing->Flags == SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL) {
+    while (WrOff == pRing->RdOff) {
+      ;
+    }
+  }
+  //
+  // Output byte if free space is available
+  //
+  if (WrOff != pRing->RdOff) {
+    pRing->pBuffer[pRing->WrOff] = c;
+    pRing->WrOff = WrOff;
+    Status = 1;
+  } else {
+    Status = 0;
+  }
+  //
+  // Finish up.
+  //
+  SEGGER_RTT_UNLOCK();
+  //
+  return Status;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_GetKey
+*
+*  Function description
+*    Reads one character from the SEGGER RTT buffer.
+*    Host has previously stored data there.
+*
+*  Return value
+*    <  0 -   No character available (buffer empty).
+*    >= 0 -   Character which has been read. (Possible values: 0 - 255)
+*
+*  Notes
+*    (1) This function is only specified for accesses to RTT buffer 0.
+*/
+int SEGGER_RTT_GetKey(void) {
+  char c;
+  int r;
+
+  r = (int)SEGGER_RTT_Read(0u, &c, 1u);
+  if (r == 1) {
+    r = (int)(unsigned char)c;
+  } else {
+    r = -1;
+  }
+  return r;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_WaitKey
+*
+*  Function description
+*    Waits until at least one character is avaible in the SEGGER RTT buffer.
+*    Once a character is available, it is read and this function returns.
+*
+*  Return value
+*    >=0 -   Character which has been read.
+*
+*  Notes
+*    (1) This function is only specified for accesses to RTT buffer 0
+*    (2) This function is blocking if no character is present in RTT buffer
+*/
+int SEGGER_RTT_WaitKey(void) {
+  int r;
+
+  do {
+    r = SEGGER_RTT_GetKey();
+  } while (r < 0);
+  return r;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_HasKey
+*
+*  Function description
+*    Checks if at least one character for reading is available in the SEGGER RTT buffer.
+*
+*  Return value
+*    == 0 -     No characters are available to read.
+*    == 1 -     At least one character is available.
+*
+*  Notes
+*    (1) This function is only specified for accesses to RTT buffer 0
+*/
+int SEGGER_RTT_HasKey(void) {
+  unsigned RdOff;
+  int r;
+
+  INIT();
+  RdOff = _SEGGER_RTT.aDown[0].RdOff;
+  if (RdOff != _SEGGER_RTT.aDown[0].WrOff) {
+    r = 1;
+  } else {
+    r = 0;
+  }
+  return r;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_HasData
+*
+*  Function description
+*    Check if there is data from the host in the given buffer.
+*
+*  Return value:
+*  ==0:  No data
+*  !=0:  Data in buffer
+*
+*/
+unsigned SEGGER_RTT_HasData(unsigned BufferIndex) {
+  SEGGER_RTT_BUFFER_DOWN* pRing;
+  unsigned                v;
+
+  pRing = &_SEGGER_RTT.aDown[BufferIndex];
+  v = pRing->WrOff;
+  return v - pRing->RdOff;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_HasDataUp
+*
+*  Function description
+*    Check if there is data remaining to be sent in the given buffer.
+*
+*  Return value:
+*  ==0:  No data
+*  !=0:  Data in buffer
+*
+*/
+unsigned SEGGER_RTT_HasDataUp(unsigned BufferIndex) {
+  SEGGER_RTT_BUFFER_UP* pRing;
+  unsigned                v;
+
+  pRing = &_SEGGER_RTT.aUp[BufferIndex];
+  v = pRing->RdOff;
+  return pRing->WrOff - v;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_AllocDownBuffer
+*
+*  Function description
+*    Run-time configuration of the next down-buffer (H->T).
+*    The next buffer, which is not used yet is configured.
+*    This includes: Buffer address, size, name, flags, ...
+*
+*  Parameters
+*    sName        Pointer to a constant name string.
+*    pBuffer      Pointer to a buffer to be used.
+*    BufferSize   Size of the buffer.
+*    Flags        Operating modes. Define behavior if buffer is full (not enough space for entire message).
+*
+*  Return value
+*    >= 0 - O.K. Buffer Index
+*     < 0 - Error
+*/
+int SEGGER_RTT_AllocDownBuffer(const char* sName, void* pBuffer, unsigned BufferSize, unsigned Flags) {
+  int BufferIndex;
+
+  INIT();
+  SEGGER_RTT_LOCK();
+  BufferIndex = 0;
+  do {
+    if (_SEGGER_RTT.aDown[BufferIndex].pBuffer == NULL) {
+      break;
+    }
+    BufferIndex++;
+  } while (BufferIndex < _SEGGER_RTT.MaxNumDownBuffers);
+  if (BufferIndex < _SEGGER_RTT.MaxNumDownBuffers) {
+    _SEGGER_RTT.aDown[BufferIndex].sName        = sName;
+    _SEGGER_RTT.aDown[BufferIndex].pBuffer      = (char*)pBuffer;
+    _SEGGER_RTT.aDown[BufferIndex].SizeOfBuffer = BufferSize;
+    _SEGGER_RTT.aDown[BufferIndex].RdOff        = 0u;
+    _SEGGER_RTT.aDown[BufferIndex].WrOff        = 0u;
+    _SEGGER_RTT.aDown[BufferIndex].Flags        = Flags;
+  } else {
+    BufferIndex = -1;
+  }
+  SEGGER_RTT_UNLOCK();
+  return BufferIndex;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_AllocUpBuffer
+*
+*  Function description
+*    Run-time configuration of the next up-buffer (T->H).
+*    The next buffer, which is not used yet is configured.
+*    This includes: Buffer address, size, name, flags, ...
+*
+*  Parameters
+*    sName        Pointer to a constant name string.
+*    pBuffer      Pointer to a buffer to be used.
+*    BufferSize   Size of the buffer.
+*    Flags        Operating modes. Define behavior if buffer is full (not enough space for entire message).
+*
+*  Return value
+*    >= 0 - O.K. Buffer Index
+*     < 0 - Error
+*/
+int SEGGER_RTT_AllocUpBuffer(const char* sName, void* pBuffer, unsigned BufferSize, unsigned Flags) {
+  int BufferIndex;
+
+  INIT();
+  SEGGER_RTT_LOCK();
+  BufferIndex = 0;
+  do {
+    if (_SEGGER_RTT.aUp[BufferIndex].pBuffer == NULL) {
+      break;
+    }
+    BufferIndex++;
+  } while (BufferIndex < _SEGGER_RTT.MaxNumUpBuffers);
+  if (BufferIndex < _SEGGER_RTT.MaxNumUpBuffers) {
+    _SEGGER_RTT.aUp[BufferIndex].sName        = sName;
+    _SEGGER_RTT.aUp[BufferIndex].pBuffer      = (char*)pBuffer;
+    _SEGGER_RTT.aUp[BufferIndex].SizeOfBuffer = BufferSize;
+    _SEGGER_RTT.aUp[BufferIndex].RdOff        = 0u;
+    _SEGGER_RTT.aUp[BufferIndex].WrOff        = 0u;
+    _SEGGER_RTT.aUp[BufferIndex].Flags        = Flags;
+  } else {
+    BufferIndex = -1;
+  }
+  SEGGER_RTT_UNLOCK();
+  return BufferIndex;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_ConfigUpBuffer
+*
+*  Function description
+*    Run-time configuration of a specific up-buffer (T->H).
+*    Buffer to be configured is specified by index.
+*    This includes: Buffer address, size, name, flags, ...
+*
+*  Parameters
+*    BufferIndex  Index of the buffer to configure.
+*    sName        Pointer to a constant name string.
+*    pBuffer      Pointer to a buffer to be used.
+*    BufferSize   Size of the buffer.
+*    Flags        Operating modes. Define behavior if buffer is full (not enough space for entire message).
+*
+*  Return value
+*    >= 0 - O.K.
+*     < 0 - Error
+*
+*  Additional information
+*    Buffer 0 is configured on compile-time.
+*    May only be called once per buffer.
+*    Buffer name and flags can be reconfigured using the appropriate functions.
+*/
+int SEGGER_RTT_ConfigUpBuffer(unsigned BufferIndex, const char* sName, void* pBuffer, unsigned BufferSize, unsigned Flags) {
+  int r;
+
+  INIT();
+  if (BufferIndex < (unsigned)_SEGGER_RTT.MaxNumUpBuffers) {
+    SEGGER_RTT_LOCK();
+    if (BufferIndex > 0u) {
+      _SEGGER_RTT.aUp[BufferIndex].sName        = sName;
+      _SEGGER_RTT.aUp[BufferIndex].pBuffer      = (char*)pBuffer;
+      _SEGGER_RTT.aUp[BufferIndex].SizeOfBuffer = BufferSize;
+      _SEGGER_RTT.aUp[BufferIndex].RdOff        = 0u;
+      _SEGGER_RTT.aUp[BufferIndex].WrOff        = 0u;
+    }
+    _SEGGER_RTT.aUp[BufferIndex].Flags          = Flags;
+    SEGGER_RTT_UNLOCK();
+    r =  0;
+  } else {
+    r = -1;
+  }
+  return r;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_ConfigDownBuffer
+*
+*  Function description
+*    Run-time configuration of a specific down-buffer (H->T).
+*    Buffer to be configured is specified by index.
+*    This includes: Buffer address, size, name, flags, ...
+*
+*  Parameters
+*    BufferIndex  Index of the buffer to configure.
+*    sName        Pointer to a constant name string.
+*    pBuffer      Pointer to a buffer to be used.
+*    BufferSize   Size of the buffer.
+*    Flags        Operating modes. Define behavior if buffer is full (not enough space for entire message).
+*
+*  Return value
+*    >= 0  O.K.
+*     < 0  Error
+*
+*  Additional information
+*    Buffer 0 is configured on compile-time.
+*    May only be called once per buffer.
+*    Buffer name and flags can be reconfigured using the appropriate functions.
+*/
+int SEGGER_RTT_ConfigDownBuffer(unsigned BufferIndex, const char* sName, void* pBuffer, unsigned BufferSize, unsigned Flags) {
+  int r;
+
+  INIT();
+  if (BufferIndex < (unsigned)_SEGGER_RTT.MaxNumDownBuffers) {
+    SEGGER_RTT_LOCK();
+    if (BufferIndex > 0u) {
+      _SEGGER_RTT.aDown[BufferIndex].sName        = sName;
+      _SEGGER_RTT.aDown[BufferIndex].pBuffer      = (char*)pBuffer;
+      _SEGGER_RTT.aDown[BufferIndex].SizeOfBuffer = BufferSize;
+      _SEGGER_RTT.aDown[BufferIndex].RdOff        = 0u;
+      _SEGGER_RTT.aDown[BufferIndex].WrOff        = 0u;
+    }
+    _SEGGER_RTT.aDown[BufferIndex].Flags          = Flags;
+    SEGGER_RTT_UNLOCK();
+    r =  0;
+  } else {
+    r = -1;
+  }
+  return r;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_SetNameUpBuffer
+*
+*  Function description
+*    Run-time configuration of a specific up-buffer name (T->H).
+*    Buffer to be configured is specified by index.
+*
+*  Parameters
+*    BufferIndex  Index of the buffer to renamed.
+*    sName        Pointer to a constant name string.
+*
+*  Return value
+*    >= 0  O.K.
+*     < 0  Error
+*/
+int SEGGER_RTT_SetNameUpBuffer(unsigned BufferIndex, const char* sName) {
+  int r;
+
+  INIT();
+  if (BufferIndex < (unsigned)_SEGGER_RTT.MaxNumUpBuffers) {
+    SEGGER_RTT_LOCK();
+    _SEGGER_RTT.aUp[BufferIndex].sName = sName;
+    SEGGER_RTT_UNLOCK();
+    r =  0;
+  } else {
+    r = -1;
+  }
+  return r;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_SetNameDownBuffer
+*
+*  Function description
+*    Run-time configuration of a specific Down-buffer name (T->H).
+*    Buffer to be configured is specified by index.
+*
+*  Parameters
+*    BufferIndex  Index of the buffer to renamed.
+*    sName        Pointer to a constant name string.
+*
+*  Return value
+*    >= 0  O.K.
+*     < 0  Error
+*/
+int SEGGER_RTT_SetNameDownBuffer(unsigned BufferIndex, const char* sName) {
+  int r;
+
+  INIT();
+  if (BufferIndex < (unsigned)_SEGGER_RTT.MaxNumDownBuffers) {
+    SEGGER_RTT_LOCK();
+    _SEGGER_RTT.aDown[BufferIndex].sName = sName;
+    SEGGER_RTT_UNLOCK();
+    r =  0;
+  } else {
+    r = -1;
+  }
+  return r;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_SetFlagsUpBuffer
+*
+*  Function description
+*    Run-time configuration of specific up-buffer flags (T->H).
+*    Buffer to be configured is specified by index.
+*
+*  Parameters
+*    BufferIndex  Index of the buffer.
+*    Flags        Flags to set for the buffer.
+*
+*  Return value
+*    >= 0  O.K.
+*     < 0  Error
+*/
+int SEGGER_RTT_SetFlagsUpBuffer(unsigned BufferIndex, unsigned Flags) {
+  int r;
+
+  INIT();
+  if (BufferIndex < (unsigned)_SEGGER_RTT.MaxNumUpBuffers) {
+    SEGGER_RTT_LOCK();
+    _SEGGER_RTT.aUp[BufferIndex].Flags = Flags;
+    SEGGER_RTT_UNLOCK();
+    r =  0;
+  } else {
+    r = -1;
+  }
+  return r;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_SetFlagsDownBuffer
+*
+*  Function description
+*    Run-time configuration of specific Down-buffer flags (T->H).
+*    Buffer to be configured is specified by index.
+*
+*  Parameters
+*    BufferIndex  Index of the buffer to renamed.
+*    Flags        Flags to set for the buffer.
+*
+*  Return value
+*    >= 0  O.K.
+*     < 0  Error
+*/
+int SEGGER_RTT_SetFlagsDownBuffer(unsigned BufferIndex, unsigned Flags) {
+  int r;
+
+  INIT();
+  if (BufferIndex < (unsigned)_SEGGER_RTT.MaxNumDownBuffers) {
+    SEGGER_RTT_LOCK();
+    _SEGGER_RTT.aDown[BufferIndex].Flags = Flags;
+    SEGGER_RTT_UNLOCK();
+    r =  0;
+  } else {
+    r = -1;
+  }
+  return r;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_Init
+*
+*  Function description
+*    Initializes the RTT Control Block.
+*    Should be used in RAM targets, at start of the application.
+*
+*/
+void SEGGER_RTT_Init (void) {
+  _DoInit();
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_SetTerminal
+*
+*  Function description
+*    Sets the terminal to be used for output on channel 0.
+*
+*  Parameters
+*    TerminalId  Index of the terminal.
+*
+*  Return value
+*    >= 0  O.K.
+*     < 0  Error (e.g. if RTT is configured for non-blocking mode and there was no space in the buffer to set the new terminal Id)
+*/
+int SEGGER_RTT_SetTerminal (char TerminalId) {
+  unsigned char         ac[2];
+  SEGGER_RTT_BUFFER_UP* pRing;
+  unsigned Avail;
+  int r;
+  //
+  INIT();
+  //
+  r = 0;
+  ac[0] = 0xFFu;
+  if ((unsigned char)TerminalId < (unsigned char)sizeof(_aTerminalId)) { // We only support a certain number of channels
+    ac[1] = _aTerminalId[(unsigned char)TerminalId];
+    pRing = &_SEGGER_RTT.aUp[0];    // Buffer 0 is always reserved for terminal I/O, so we can use index 0 here, fixed
+    SEGGER_RTT_LOCK();    // Lock to make sure that no other task is writing into buffer, while we are and number of free bytes in buffer does not change downwards after checking and before writing
+    if ((pRing->Flags & SEGGER_RTT_MODE_MASK) == SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL) {
+      _ActiveTerminal = TerminalId;
+      _WriteBlocking(pRing, (const char*)ac, 2u);
+    } else {                                                                            // Skipping mode or trim mode? => We cannot trim this command so handling is the same for both modes
+      Avail = _GetAvailWriteSpace(pRing);
+      if (Avail >= 2) {
+        _ActiveTerminal = TerminalId;    // Only change active terminal in case of success
+        _WriteNoCheck(pRing, (const char*)ac, 2u);
+      } else {
+        r = -1;
+      }
+    }
+    SEGGER_RTT_UNLOCK();
+  } else {
+    r = -1;
+  }
+  return r;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_TerminalOut
+*
+*  Function description
+*    Writes a string to the given terminal
+*     without changing the terminal for channel 0.
+*
+*  Parameters
+*    TerminalId   Index of the terminal.
+*    s            String to be printed on the terminal.
+*
+*  Return value
+*    >= 0 - Number of bytes written.
+*     < 0 - Error.
+*
+*/
+int SEGGER_RTT_TerminalOut (char TerminalId, const char* s) {
+  int                   Status;
+  unsigned              FragLen;
+  unsigned              Avail;
+  SEGGER_RTT_BUFFER_UP* pRing;
+  //
+  INIT();
+  //
+  // Validate terminal ID.
+  //
+  if (TerminalId < (char)sizeof(_aTerminalId)) { // We only support a certain number of channels
+    //
+    // Get "to-host" ring buffer.
+    //
+    pRing = &_SEGGER_RTT.aUp[0];
+    //
+    // Need to be able to change terminal, write data, change back.
+    // Compute the fixed and variable sizes.
+    //
+    FragLen = STRLEN(s);
+    //
+    // How we output depends upon the mode...
+    //
+    SEGGER_RTT_LOCK();
+    Avail = _GetAvailWriteSpace(pRing);
+    switch (pRing->Flags & SEGGER_RTT_MODE_MASK) {
+    case SEGGER_RTT_MODE_NO_BLOCK_SKIP:
+      //
+      // If we are in skip mode and there is no space for the whole
+      // of this output, don't bother switching terminals at all.
+      //
+      if (Avail < (FragLen + 4u)) {
+        Status = 0;
+      } else {
+        _PostTerminalSwitch(pRing, TerminalId);
+        Status = (int)_WriteBlocking(pRing, s, FragLen);
+        _PostTerminalSwitch(pRing, _ActiveTerminal);
+      }
+      break;
+    case SEGGER_RTT_MODE_NO_BLOCK_TRIM:
+      //
+      // If we are in trim mode and there is not enough space for everything,
+      // trim the output but always include the terminal switch.  If no room
+      // for terminal switch, skip that totally.
+      //
+      if (Avail < 4u) {
+        Status = -1;
+      } else {
+        _PostTerminalSwitch(pRing, TerminalId);
+        Status = (int)_WriteBlocking(pRing, s, (FragLen < (Avail - 4u)) ? FragLen : (Avail - 4u));
+        _PostTerminalSwitch(pRing, _ActiveTerminal);
+      }
+      break;
+    case SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL:
+      //
+      // If we are in blocking mode, output everything.
+      //
+      _PostTerminalSwitch(pRing, TerminalId);
+      Status = (int)_WriteBlocking(pRing, s, FragLen);
+      _PostTerminalSwitch(pRing, _ActiveTerminal);
+      break;
+    default:
+      Status = -1;
+      break;
+    }
+    //
+    // Finish up.
+    //
+    SEGGER_RTT_UNLOCK();
+  } else {
+    Status = -1;
+  }
+  return Status;
+}
+
+
+/*************************** End of file ****************************/

--- a/tests/functional/firmware/k21-rtt/vendor/SEGGER_RTT.h
+++ b/tests/functional/firmware/k21-rtt/vendor/SEGGER_RTT.h
@@ -1,0 +1,255 @@
+/*********************************************************************
+*                    SEGGER Microcontroller GmbH                     *
+*                        The Embedded Experts                        *
+**********************************************************************
+*                                                                    *
+*            (c) 1995 - 2018 SEGGER Microcontroller GmbH             *
+*                                                                    *
+*       www.segger.com     Support: support@segger.com               *
+*                                                                    *
+**********************************************************************
+*                                                                    *
+*       SEGGER RTT * Real Time Transfer for embedded targets         *
+*                                                                    *
+**********************************************************************
+*                                                                    *
+* All rights reserved.                                               *
+*                                                                    *
+* SEGGER strongly recommends to not make any changes                 *
+* to or modify the source code of this software in order to stay     *
+* compatible with the RTT protocol and J-Link.                       *
+*                                                                    *
+* Redistribution and use in source and binary forms, with or         *
+* without modification, are permitted provided that the following    *
+* conditions are met:                                                *
+*                                                                    *
+* o Redistributions of source code must retain the above copyright   *
+*   notice, this list of conditions and the following disclaimer.    *
+*                                                                    *
+* o Redistributions in binary form must reproduce the above          *
+*   copyright notice, this list of conditions and the following      *
+*   disclaimer in the documentation and/or other materials provided  *
+*   with the distribution.                                           *
+*                                                                    *
+* o Neither the name of SEGGER Microcontroller GmbH                  *
+*   nor the names of its contributors may be used to endorse or      *
+*   promote products derived from this software without specific     *
+*   prior written permission.                                        *
+*                                                                    *
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND             *
+* CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,        *
+* INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF           *
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+* DISCLAIMED. IN NO EVENT SHALL SEGGER Microcontroller BE LIABLE FOR *
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR           *
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT  *
+* OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;    *
+* OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF      *
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT          *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE  *
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH   *
+* DAMAGE.                                                            *
+*                                                                    *
+**********************************************************************
+---------------------------END-OF-HEADER------------------------------
+File    : SEGGER_RTT.h
+Purpose : Implementation of SEGGER real-time transfer which allows
+          real-time communication on targets which support debugger
+          memory accesses while the CPU is running.
+Revision: $Rev: 12826 $
+----------------------------------------------------------------------
+*/
+
+#ifndef SEGGER_RTT_H
+#define SEGGER_RTT_H
+
+#include "SEGGER_RTT_Conf.h"
+#ifndef SEGGER_RTT_ASM  // defined when SEGGER_RTT.h is included from assembly file
+#include <stdlib.h>
+#include <stdarg.h>
+
+/*********************************************************************
+*
+*       Defines, fixed
+*
+**********************************************************************
+*/
+
+/*********************************************************************
+*
+*       Types
+*
+**********************************************************************
+*/
+
+//
+// Description for a circular buffer (also called "ring buffer")
+// which is used as up-buffer (T->H)
+//
+typedef struct {
+  const     char*    sName;         // Optional name. Standard names so far are: "Terminal", "SysView", "J-Scope_t4i4"
+            char*    pBuffer;       // Pointer to start of buffer
+            unsigned SizeOfBuffer;  // Buffer size in bytes. Note that one byte is lost, as this implementation does not fill up the buffer in order to avoid the problem of being unable to distinguish between full and empty.
+            unsigned WrOff;         // Position of next item to be written by either target.
+  volatile  unsigned RdOff;         // Position of next item to be read by host. Must be volatile since it may be modified by host.
+            unsigned Flags;         // Contains configuration flags
+} SEGGER_RTT_BUFFER_UP;
+
+//
+// Description for a circular buffer (also called "ring buffer")
+// which is used as down-buffer (H->T)
+//
+typedef struct {
+  const     char*    sName;         // Optional name. Standard names so far are: "Terminal", "SysView", "J-Scope_t4i4"
+            char*    pBuffer;       // Pointer to start of buffer
+            unsigned SizeOfBuffer;  // Buffer size in bytes. Note that one byte is lost, as this implementation does not fill up the buffer in order to avoid the problem of being unable to distinguish between full and empty.
+  volatile  unsigned WrOff;         // Position of next item to be written by host. Must be volatile since it may be modified by host.
+            unsigned RdOff;         // Position of next item to be read by target (down-buffer).
+            unsigned Flags;         // Contains configuration flags
+} SEGGER_RTT_BUFFER_DOWN;
+
+//
+// RTT control block which describes the number of buffers available
+// as well as the configuration for each buffer
+//
+//
+typedef struct {
+  char                    acID[16];                                 // Initialized to "SEGGER RTT"
+  int                     MaxNumUpBuffers;                          // Initialized to SEGGER_RTT_MAX_NUM_UP_BUFFERS (type. 2)
+  int                     MaxNumDownBuffers;                        // Initialized to SEGGER_RTT_MAX_NUM_DOWN_BUFFERS (type. 2)
+  SEGGER_RTT_BUFFER_UP    aUp[SEGGER_RTT_MAX_NUM_UP_BUFFERS];       // Up buffers, transferring information up from target via debug probe to host
+  SEGGER_RTT_BUFFER_DOWN  aDown[SEGGER_RTT_MAX_NUM_DOWN_BUFFERS];   // Down buffers, transferring information down from host via debug probe to target
+} SEGGER_RTT_CB;
+
+/*********************************************************************
+*
+*       Global data
+*
+**********************************************************************
+*/
+extern SEGGER_RTT_CB _SEGGER_RTT;
+
+/*********************************************************************
+*
+*       RTT API functions
+*
+**********************************************************************
+*/
+#ifdef __cplusplus
+  extern "C" {
+#endif
+int          SEGGER_RTT_AllocDownBuffer         (const char* sName, void* pBuffer, unsigned BufferSize, unsigned Flags);
+int          SEGGER_RTT_AllocUpBuffer           (const char* sName, void* pBuffer, unsigned BufferSize, unsigned Flags);
+int          SEGGER_RTT_ConfigUpBuffer          (unsigned BufferIndex, const char* sName, void* pBuffer, unsigned BufferSize, unsigned Flags);
+int          SEGGER_RTT_ConfigDownBuffer        (unsigned BufferIndex, const char* sName, void* pBuffer, unsigned BufferSize, unsigned Flags);
+int          SEGGER_RTT_GetKey                  (void);
+unsigned     SEGGER_RTT_HasData                 (unsigned BufferIndex);
+int          SEGGER_RTT_HasKey                  (void);
+unsigned     SEGGER_RTT_HasDataUp               (unsigned BufferIndex);
+void         SEGGER_RTT_Init                    (void);
+unsigned     SEGGER_RTT_Read                    (unsigned BufferIndex,       void* pBuffer, unsigned BufferSize);
+unsigned     SEGGER_RTT_ReadNoLock              (unsigned BufferIndex,       void* pData,   unsigned BufferSize);
+int          SEGGER_RTT_SetNameDownBuffer       (unsigned BufferIndex, const char* sName);
+int          SEGGER_RTT_SetNameUpBuffer         (unsigned BufferIndex, const char* sName);
+int          SEGGER_RTT_SetFlagsDownBuffer      (unsigned BufferIndex, unsigned Flags);
+int          SEGGER_RTT_SetFlagsUpBuffer        (unsigned BufferIndex, unsigned Flags);
+int          SEGGER_RTT_WaitKey                 (void);
+unsigned     SEGGER_RTT_Write                   (unsigned BufferIndex, const void* pBuffer, unsigned NumBytes);
+unsigned     SEGGER_RTT_WriteNoLock             (unsigned BufferIndex, const void* pBuffer, unsigned NumBytes);
+unsigned     SEGGER_RTT_WriteSkipNoLock         (unsigned BufferIndex, const void* pBuffer, unsigned NumBytes);
+unsigned     SEGGER_RTT_WriteString             (unsigned BufferIndex, const char* s);
+void         SEGGER_RTT_WriteWithOverwriteNoLock(unsigned BufferIndex, const void* pBuffer, unsigned NumBytes);
+unsigned     SEGGER_RTT_PutChar                 (unsigned BufferIndex, char c);
+unsigned     SEGGER_RTT_PutCharSkip             (unsigned BufferIndex, char c);
+unsigned     SEGGER_RTT_PutCharSkipNoLock       (unsigned BufferIndex, char c);
+//
+// Function macro for performance optimization
+//
+#define      SEGGER_RTT_HASDATA(n)       (_SEGGER_RTT.aDown[n].WrOff - _SEGGER_RTT.aDown[n].RdOff)
+
+/*********************************************************************
+*
+*       RTT "Terminal" API functions
+*
+**********************************************************************
+*/
+int     SEGGER_RTT_SetTerminal        (char TerminalId);
+int     SEGGER_RTT_TerminalOut        (char TerminalId, const char* s);
+
+/*********************************************************************
+*
+*       RTT printf functions (require SEGGER_RTT_printf.c)
+*
+**********************************************************************
+*/
+int SEGGER_RTT_printf(unsigned BufferIndex, const char * sFormat, ...);
+int SEGGER_RTT_vprintf(unsigned BufferIndex, const char * sFormat, va_list * pParamList);
+
+#ifdef __cplusplus
+  }
+#endif
+
+#endif // SEGGER_RTT_ASM
+
+/*********************************************************************
+*
+*       Defines
+*
+**********************************************************************
+*/
+
+//
+// Operating modes. Define behavior if buffer is full (not enough space for entire message)
+//
+#define SEGGER_RTT_MODE_NO_BLOCK_SKIP         (0)     // Skip. Do not block, output nothing. (Default)
+#define SEGGER_RTT_MODE_NO_BLOCK_TRIM         (1)     // Trim: Do not block, output as much as fits.
+#define SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL    (2)     // Block: Wait until there is space in the buffer.
+#define SEGGER_RTT_MODE_MASK                  (3)
+
+//
+// Control sequences, based on ANSI.
+// Can be used to control color, and clear the screen
+//
+#define RTT_CTRL_RESET                "\x1B[0m"         // Reset to default colors
+#define RTT_CTRL_CLEAR                "\x1B[2J"         // Clear screen, reposition cursor to top left
+
+#define RTT_CTRL_TEXT_BLACK           "\x1B[2;30m"
+#define RTT_CTRL_TEXT_RED             "\x1B[2;31m"
+#define RTT_CTRL_TEXT_GREEN           "\x1B[2;32m"
+#define RTT_CTRL_TEXT_YELLOW          "\x1B[2;33m"
+#define RTT_CTRL_TEXT_BLUE            "\x1B[2;34m"
+#define RTT_CTRL_TEXT_MAGENTA         "\x1B[2;35m"
+#define RTT_CTRL_TEXT_CYAN            "\x1B[2;36m"
+#define RTT_CTRL_TEXT_WHITE           "\x1B[2;37m"
+
+#define RTT_CTRL_TEXT_BRIGHT_BLACK    "\x1B[1;30m"
+#define RTT_CTRL_TEXT_BRIGHT_RED      "\x1B[1;31m"
+#define RTT_CTRL_TEXT_BRIGHT_GREEN    "\x1B[1;32m"
+#define RTT_CTRL_TEXT_BRIGHT_YELLOW   "\x1B[1;33m"
+#define RTT_CTRL_TEXT_BRIGHT_BLUE     "\x1B[1;34m"
+#define RTT_CTRL_TEXT_BRIGHT_MAGENTA  "\x1B[1;35m"
+#define RTT_CTRL_TEXT_BRIGHT_CYAN     "\x1B[1;36m"
+#define RTT_CTRL_TEXT_BRIGHT_WHITE    "\x1B[1;37m"
+
+#define RTT_CTRL_BG_BLACK             "\x1B[24;40m"
+#define RTT_CTRL_BG_RED               "\x1B[24;41m"
+#define RTT_CTRL_BG_GREEN             "\x1B[24;42m"
+#define RTT_CTRL_BG_YELLOW            "\x1B[24;43m"
+#define RTT_CTRL_BG_BLUE              "\x1B[24;44m"
+#define RTT_CTRL_BG_MAGENTA           "\x1B[24;45m"
+#define RTT_CTRL_BG_CYAN              "\x1B[24;46m"
+#define RTT_CTRL_BG_WHITE             "\x1B[24;47m"
+
+#define RTT_CTRL_BG_BRIGHT_BLACK      "\x1B[4;40m"
+#define RTT_CTRL_BG_BRIGHT_RED        "\x1B[4;41m"
+#define RTT_CTRL_BG_BRIGHT_GREEN      "\x1B[4;42m"
+#define RTT_CTRL_BG_BRIGHT_YELLOW     "\x1B[4;43m"
+#define RTT_CTRL_BG_BRIGHT_BLUE       "\x1B[4;44m"
+#define RTT_CTRL_BG_BRIGHT_MAGENTA    "\x1B[4;45m"
+#define RTT_CTRL_BG_BRIGHT_CYAN       "\x1B[4;46m"
+#define RTT_CTRL_BG_BRIGHT_WHITE      "\x1B[4;47m"
+
+
+#endif
+
+/*************************** End of file ****************************/

--- a/tests/functional/firmware/k21-rtt/vendor/SEGGER_RTT_Conf.h
+++ b/tests/functional/firmware/k21-rtt/vendor/SEGGER_RTT_Conf.h
@@ -1,0 +1,340 @@
+/*********************************************************************
+*                    SEGGER Microcontroller GmbH                     *
+*                        The Embedded Experts                        *
+**********************************************************************
+*                                                                    *
+*            (c) 1995 - 2018 SEGGER Microcontroller GmbH             *
+*                                                                    *
+*       www.segger.com     Support: support@segger.com               *
+*                                                                    *
+**********************************************************************
+*                                                                    *
+*       SEGGER RTT * Real Time Transfer for embedded targets         *
+*                                                                    *
+**********************************************************************
+*                                                                    *
+* All rights reserved.                                               *
+*                                                                    *
+* SEGGER strongly recommends to not make any changes                 *
+* to or modify the source code of this software in order to stay     *
+* compatible with the RTT protocol and J-Link.                       *
+*                                                                    *
+* Redistribution and use in source and binary forms, with or         *
+* without modification, are permitted provided that the following    *
+* conditions are met:                                                *
+*                                                                    *
+* o Redistributions of source code must retain the above copyright   *
+*   notice, this list of conditions and the following disclaimer.    *
+*                                                                    *
+* o Redistributions in binary form must reproduce the above          *
+*   copyright notice, this list of conditions and the following      *
+*   disclaimer in the documentation and/or other materials provided  *
+*   with the distribution.                                           *
+*                                                                    *
+* o Neither the name of SEGGER Microcontroller GmbH                  *
+*   nor the names of its contributors may be used to endorse or      *
+*   promote products derived from this software without specific     *
+*   prior written permission.                                        *
+*                                                                    *
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND             *
+* CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,        *
+* INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF           *
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+* DISCLAIMED. IN NO EVENT SHALL SEGGER Microcontroller BE LIABLE FOR *
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR           *
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT  *
+* OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;    *
+* OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF      *
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT          *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE  *
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH   *
+* DAMAGE.                                                            *
+*                                                                    *
+**********************************************************************
+---------------------------END-OF-HEADER------------------------------
+File    : SEGGER_RTT_Conf.h
+Purpose : Implementation of SEGGER real-time transfer (RTT) which
+          allows real-time communication on targets which support
+          debugger memory accesses while the CPU is running.
+Revision: $Rev: 12847 $
+
+*/
+
+#ifndef SEGGER_RTT_CONF_H
+#define SEGGER_RTT_CONF_H
+
+#ifdef __IAR_SYSTEMS_ICC__
+  #include <intrinsics.h>
+#endif
+
+/*********************************************************************
+*
+*       Defines, configurable
+*
+**********************************************************************
+*/
+
+#define SEGGER_RTT_MAX_NUM_UP_BUFFERS             (3)     // Max. number of up-buffers (T->H) available on this target    (Default: 3)
+#define SEGGER_RTT_MAX_NUM_DOWN_BUFFERS           (3)     // Max. number of down-buffers (H->T) available on this target  (Default: 3)
+
+#define BUFFER_SIZE_UP                            (1024)  // Size of the buffer for terminal output of target, up to host (Default: 1k)
+#define BUFFER_SIZE_DOWN                          (16)    // Size of the buffer for terminal input to target from host (Usually keyboard input) (Default: 16)
+
+#define SEGGER_RTT_PRINTF_BUFFER_SIZE             (64u)    // Size of buffer for RTT printf to bulk-send chars via RTT     (Default: 64)
+
+#define SEGGER_RTT_MODE_DEFAULT                   SEGGER_RTT_MODE_NO_BLOCK_SKIP // Mode for pre-initialized terminal channel (buffer 0)
+
+#define USE_RTT_ASM                               (0)     // Use assembler version of SEGGER_RTT.c when 1
+
+/*********************************************************************
+*
+*       RTT memcpy configuration
+*
+*       memcpy() is good for large amounts of data,
+*       but the overhead is big for small amounts, which are usually stored via RTT.
+*       With SEGGER_RTT_MEMCPY_USE_BYTELOOP a simple byte loop can be used instead.
+*
+*       SEGGER_RTT_MEMCPY() can be used to replace standard memcpy() in RTT functions.
+*       This is may be required with memory access restrictions,
+*       such as on Cortex-A devices with MMU.
+*/
+#define SEGGER_RTT_MEMCPY_USE_BYTELOOP              0 // 0: Use memcpy/SEGGER_RTT_MEMCPY, 1: Use a simple byte-loop
+//
+// Example definition of SEGGER_RTT_MEMCPY to external memcpy with GCC toolchains and Cortex-A targets
+//
+//#if ((defined __SES_ARM) || (defined __CROSSWORKS_ARM) || (defined __GNUC__)) && (defined (__ARM_ARCH_7A__))
+//  #define SEGGER_RTT_MEMCPY(pDest, pSrc, NumBytes)      SEGGER_memcpy((pDest), (pSrc), (NumBytes))
+//#endif
+
+//
+// Target is not allowed to perform other RTT operations while string still has not been stored completely.
+// Otherwise we would probably end up with a mixed string in the buffer.
+// If using  RTT from within interrupts, multiple tasks or multi processors, define the SEGGER_RTT_LOCK() and SEGGER_RTT_UNLOCK() function here.
+//
+// SEGGER_RTT_MAX_INTERRUPT_PRIORITY can be used in the sample lock routines on Cortex-M3/4.
+// Make sure to mask all interrupts which can send RTT data, i.e. generate SystemView events, or cause task switches.
+// When high-priority interrupts must not be masked while sending RTT data, SEGGER_RTT_MAX_INTERRUPT_PRIORITY needs to be adjusted accordingly.
+// (Higher priority = lower priority number)
+// Default value for embOS: 128u
+// Default configuration in FreeRTOS: configMAX_SYSCALL_INTERRUPT_PRIORITY: ( configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - configPRIO_BITS) )
+// In case of doubt mask all interrupts: 1 << (8 - BASEPRI_PRIO_BITS) i.e. 1 << 5 when 3 bits are implemented in NVIC
+// or define SEGGER_RTT_LOCK() to completely disable interrupts.
+//
+
+#define SEGGER_RTT_MAX_INTERRUPT_PRIORITY         (0x20)   // Interrupt priority to lock on SEGGER_RTT_LOCK on Cortex-M3/4 (Default: 0x20)
+
+/*********************************************************************
+*
+*       RTT lock configuration for SEGGER Embedded Studio,
+*       Rowley CrossStudio and GCC
+*/
+#if (defined __SES_ARM) || (defined __CROSSWORKS_ARM) || (defined __GNUC__) || (defined __clang__)
+  #if (defined(__ARM_ARCH_6M__) || defined(__ARM_ARCH_8M_BASE__))
+    #define SEGGER_RTT_LOCK()   {                                                                   \
+                                    unsigned int LockState;                                         \
+                                  __asm volatile ("mrs   %0, primask  \n\t"                         \
+                                                  "movs  r1, $1       \n\t"                         \
+                                                  "msr   primask, r1  \n\t"                         \
+                                                  : "=r" (LockState)                                \
+                                                  :                                                 \
+                                                  : "r1"                                            \
+                                                  );
+
+    #define SEGGER_RTT_UNLOCK()   __asm volatile ("msr   primask, %0  \n\t"                         \
+                                                  :                                                 \
+                                                  : "r" (LockState)                                 \
+                                                  :                                                 \
+                                                  );                                                \
+                                }
+  #elif (defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__) || defined(__ARM_ARCH_8M_MAIN__))
+    #ifndef   SEGGER_RTT_MAX_INTERRUPT_PRIORITY
+      #define SEGGER_RTT_MAX_INTERRUPT_PRIORITY   (0x20)
+    #endif
+    #define SEGGER_RTT_LOCK()   {                                                                   \
+                                    unsigned int LockState;                                         \
+                                  __asm volatile ("mrs   %0, basepri  \n\t"                         \
+                                                  "mov   r1, %1       \n\t"                         \
+                                                  "msr   basepri, r1  \n\t"                         \
+                                                  : "=r" (LockState)                                \
+                                                  : "i"(SEGGER_RTT_MAX_INTERRUPT_PRIORITY)          \
+                                                  : "r1"                                            \
+                                                  );
+
+    #define SEGGER_RTT_UNLOCK()   __asm volatile ("msr   basepri, %0  \n\t"                         \
+                                                  :                                                 \
+                                                  : "r" (LockState)                                 \
+                                                  :                                                 \
+                                                  );                                                \
+                                }
+
+  #elif defined(__ARM_ARCH_7A__)
+    #define SEGGER_RTT_LOCK() {                                                \
+                                 unsigned int LockState;                       \
+                                 __asm volatile ("mrs r1, CPSR \n\t"           \
+                                                 "mov %0, r1 \n\t"             \
+                                                 "orr r1, r1, #0xC0 \n\t"      \
+                                                 "msr CPSR_c, r1 \n\t"         \
+                                                 : "=r" (LockState)            \
+                                                 :                             \
+                                                 : "r1"                        \
+                                                 );
+
+    #define SEGGER_RTT_UNLOCK() __asm volatile ("mov r0, %0 \n\t"              \
+                                                "mrs r1, CPSR \n\t"            \
+                                                "bic r1, r1, #0xC0 \n\t"       \
+                                                "and r0, r0, #0xC0 \n\t"       \
+                                                "orr r1, r1, r0 \n\t"          \
+                                                "msr CPSR_c, r1 \n\t"          \
+                                                :                              \
+                                                : "r" (LockState)              \
+                                                : "r0", "r1"                   \
+                                                );                             \
+                            }
+#else
+    #define SEGGER_RTT_LOCK()
+    #define SEGGER_RTT_UNLOCK()
+  #endif
+#endif
+
+/*********************************************************************
+*
+*       RTT lock configuration for IAR EWARM
+*/
+#ifdef __ICCARM__
+  #if (defined (__ARM6M__) && (__CORE__ == __ARM6M__))
+    #define SEGGER_RTT_LOCK()   {                                                                   \
+                                  unsigned int LockState;                                           \
+                                  LockState = __get_PRIMASK();                                      \
+                                  __set_PRIMASK(1);
+
+    #define SEGGER_RTT_UNLOCK()   __set_PRIMASK(LockState);                                         \
+                                }
+  #elif ((defined (__ARM7EM__) && (__CORE__ == __ARM7EM__)) || (defined (__ARM7M__) && (__CORE__ == __ARM7M__)))
+    #ifndef   SEGGER_RTT_MAX_INTERRUPT_PRIORITY
+      #define SEGGER_RTT_MAX_INTERRUPT_PRIORITY   (0x20)
+    #endif
+    #define SEGGER_RTT_LOCK()   {                                                                   \
+                                  unsigned int LockState;                                           \
+                                  LockState = __get_BASEPRI();                                      \
+                                  __set_BASEPRI(SEGGER_RTT_MAX_INTERRUPT_PRIORITY);
+
+    #define SEGGER_RTT_UNLOCK()   __set_BASEPRI(LockState);                                         \
+                                }
+  #endif
+#endif
+
+/*********************************************************************
+*
+*       RTT lock configuration for IAR RX
+*/
+#ifdef __ICCRX__
+  #define SEGGER_RTT_LOCK()   {                                                                     \
+                                unsigned long LockState;                                            \
+                                LockState = __get_interrupt_state();                                \
+                                __disable_interrupt();
+
+  #define SEGGER_RTT_UNLOCK()   __set_interrupt_state(LockState);                                   \
+                              }
+#endif
+
+/*********************************************************************
+*
+*       RTT lock configuration for IAR RL78
+*/
+#ifdef __ICCRL78__
+  #define SEGGER_RTT_LOCK()   {                                                                     \
+                                __istate_t LockState;                                               \
+                                LockState = __get_interrupt_state();                                \
+                                __disable_interrupt();
+
+  #define SEGGER_RTT_UNLOCK()   __set_interrupt_state(LockState);                                   \
+                              }
+#endif
+
+/*********************************************************************
+*
+*       RTT lock configuration for KEIL ARM
+*/
+#ifdef __CC_ARM
+  #if (defined __TARGET_ARCH_6S_M)
+    #define SEGGER_RTT_LOCK()   {                                                                   \
+                                  unsigned int LockState;                                           \
+                                  register unsigned char PRIMASK __asm( "primask");                 \
+                                  LockState = PRIMASK;                                              \
+                                  PRIMASK = 1u;                                                     \
+                                  __schedule_barrier();
+
+    #define SEGGER_RTT_UNLOCK()   PRIMASK = LockState;                                              \
+                                  __schedule_barrier();                                             \
+                                }
+  #elif (defined(__TARGET_ARCH_7_M) || defined(__TARGET_ARCH_7E_M))
+    #ifndef   SEGGER_RTT_MAX_INTERRUPT_PRIORITY
+      #define SEGGER_RTT_MAX_INTERRUPT_PRIORITY   (0x20)
+    #endif
+    #define SEGGER_RTT_LOCK()   {                                                                   \
+                                  unsigned int LockState;                                           \
+                                  register unsigned char BASEPRI __asm( "basepri");                 \
+                                  LockState = BASEPRI;                                              \
+                                  BASEPRI = SEGGER_RTT_MAX_INTERRUPT_PRIORITY;                      \
+                                  __schedule_barrier();
+
+    #define SEGGER_RTT_UNLOCK()   BASEPRI = LockState;                                              \
+                                  __schedule_barrier();                                             \
+                                }
+  #endif
+#endif
+
+/*********************************************************************
+*
+*       RTT lock configuration for TI ARM
+*/
+#ifdef __TI_ARM__
+  #if defined (__TI_ARM_V6M0__)
+    #define SEGGER_RTT_LOCK()   {                                                                   \
+                                  unsigned int LockState;                                           \
+                                  LockState = __get_PRIMASK();                                      \
+                                  __set_PRIMASK(1);
+
+    #define SEGGER_RTT_UNLOCK()   __set_PRIMASK(LockState);                                         \
+                                }
+  #elif (defined (__TI_ARM_V7M3__) || defined (__TI_ARM_V7M4__))
+    #ifndef   SEGGER_RTT_MAX_INTERRUPT_PRIORITY
+      #define SEGGER_RTT_MAX_INTERRUPT_PRIORITY   (0x20)
+    #endif
+    #define SEGGER_RTT_LOCK()   {                                                                   \
+                                  unsigned int LockState;                                           \
+                                  LockState = _set_interrupt_priority(SEGGER_RTT_MAX_INTERRUPT_PRIORITY);
+
+    #define SEGGER_RTT_UNLOCK()   _set_interrupt_priority(LockState);                               \
+                                }
+  #endif
+#endif
+
+/*********************************************************************
+*
+*       RTT lock configuration for CCRX
+*/
+#ifdef __RX
+  #define SEGGER_RTT_LOCK()   {                                                                     \
+                                unsigned long LockState;                                            \
+                                LockState = get_psw() & 0x010000;                                   \
+                                clrpsw_i();
+
+  #define SEGGER_RTT_UNLOCK()   set_psw(get_psw() | LockState);                                     \
+                              }
+#endif
+
+/*********************************************************************
+*
+*       RTT lock configuration fallback
+*/
+#ifndef   SEGGER_RTT_LOCK
+  #define SEGGER_RTT_LOCK()                // Lock RTT (nestable)   (i.e. disable interrupts)
+#endif
+
+#ifndef   SEGGER_RTT_UNLOCK
+  #define SEGGER_RTT_UNLOCK()              // Unlock RTT (nestable) (i.e. enable previous interrupt lock state)
+#endif
+
+#endif
+/*************************** End of file ****************************/

--- a/tests/functional/firmware/k21-rtt/vendor/SEGGER_RTT_printf.c
+++ b/tests/functional/firmware/k21-rtt/vendor/SEGGER_RTT_printf.c
@@ -1,0 +1,510 @@
+/*********************************************************************
+*                    SEGGER Microcontroller GmbH                     *
+*       Solutions for real time microcontroller applications         *
+**********************************************************************
+*                                                                    *
+*            (c) 1995 - 2018 SEGGER Microcontroller GmbH             *
+*                                                                    *
+*       www.segger.com     Support: support@segger.com               *
+*                                                                    *
+**********************************************************************
+*                                                                    *
+*       SEGGER RTT * Real Time Transfer for embedded targets         *
+*                                                                    *
+**********************************************************************
+*                                                                    *
+* All rights reserved.                                               *
+*                                                                    *
+* SEGGER strongly recommends to not make any changes                 *
+* to or modify the source code of this software in order to stay     *
+* compatible with the RTT protocol and J-Link.                       *
+*                                                                    *
+* Redistribution and use in source and binary forms, with or         *
+* without modification, are permitted provided that the following    *
+* conditions are met:                                                *
+*                                                                    *
+* o Redistributions of source code must retain the above copyright   *
+*   notice, this list of conditions and the following disclaimer.    *
+*                                                                    *
+* o Redistributions in binary form must reproduce the above          *
+*   copyright notice, this list of conditions and the following      *
+*   disclaimer in the documentation and/or other materials provided  *
+*   with the distribution.                                           *
+*                                                                    *
+* o Neither the name of SEGGER Microcontroller GmbH         *
+*   nor the names of its contributors may be used to endorse or      *
+*   promote products derived from this software without specific     *
+*   prior written permission.                                        *
+*                                                                    *
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND             *
+* CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,        *
+* INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF           *
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+* DISCLAIMED. IN NO EVENT SHALL SEGGER Microcontroller BE LIABLE FOR *
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR           *
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT  *
+* OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;    *
+* OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF      *
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT          *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE  *
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH   *
+* DAMAGE.                                                            *
+*                                                                    *
+**********************************************************************
+---------------------------END-OF-HEADER------------------------------
+File    : SEGGER_RTT_printf.c
+Purpose : Replacement for printf to write formatted data via RTT
+Revision: $Rev: 12360 $
+----------------------------------------------------------------------
+*/
+#include "SEGGER_RTT.h"
+#include "SEGGER_RTT_Conf.h"
+
+/*********************************************************************
+*
+*       Defines, configurable
+*
+**********************************************************************
+*/
+
+#ifndef SEGGER_RTT_PRINTF_BUFFER_SIZE
+  #define SEGGER_RTT_PRINTF_BUFFER_SIZE (64)
+#endif
+
+#include <stdlib.h>
+#include <stdarg.h>
+
+
+#define FORMAT_FLAG_LEFT_JUSTIFY   (1u << 0)
+#define FORMAT_FLAG_PAD_ZERO       (1u << 1)
+#define FORMAT_FLAG_PRINT_SIGN     (1u << 2)
+#define FORMAT_FLAG_ALTERNATE      (1u << 3)
+
+/*********************************************************************
+*
+*       Types
+*
+**********************************************************************
+*/
+
+typedef struct {
+  char*     pBuffer;
+  unsigned  BufferSize;
+  unsigned  Cnt;
+
+  int   ReturnValue;
+
+  unsigned RTTBufferIndex;
+} SEGGER_RTT_PRINTF_DESC;
+
+/*********************************************************************
+*
+*       Function prototypes
+*
+**********************************************************************
+*/
+
+/*********************************************************************
+*
+*       Static code
+*
+**********************************************************************
+*/
+/*********************************************************************
+*
+*       _StoreChar
+*/
+static void _StoreChar(SEGGER_RTT_PRINTF_DESC * p, char c) {
+  unsigned Cnt;
+
+  Cnt = p->Cnt;
+  if ((Cnt + 1u) <= p->BufferSize) {
+    *(p->pBuffer + Cnt) = c;
+    p->Cnt = Cnt + 1u;
+    p->ReturnValue++;
+  }
+  //
+  // Write part of string, when the buffer is full
+  //
+  if (p->Cnt == p->BufferSize) {
+    if (SEGGER_RTT_Write(p->RTTBufferIndex, p->pBuffer, p->Cnt) != p->Cnt) {
+      p->ReturnValue = -1;
+    } else {
+      p->Cnt = 0u;
+    }
+  }
+}
+
+/*********************************************************************
+*
+*       _PrintUnsigned
+*/
+static void _PrintUnsigned(SEGGER_RTT_PRINTF_DESC * pBufferDesc, unsigned v, unsigned Base, unsigned NumDigits, unsigned FieldWidth, unsigned FormatFlags) {
+  static const char _aV2C[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+  unsigned Div;
+  unsigned Digit;
+  unsigned Number;
+  unsigned Width;
+  char c;
+
+  Number = v;
+  Digit = 1u;
+  //
+  // Get actual field width
+  //
+  Width = 1u;
+  while (Number >= Base) {
+    Number = (Number / Base);
+    Width++;
+  }
+  if (NumDigits > Width) {
+    Width = NumDigits;
+  }
+  //
+  // Print leading chars if necessary
+  //
+  if ((FormatFlags & FORMAT_FLAG_LEFT_JUSTIFY) == 0u) {
+    if (FieldWidth != 0u) {
+      if (((FormatFlags & FORMAT_FLAG_PAD_ZERO) == FORMAT_FLAG_PAD_ZERO) && (NumDigits == 0u)) {
+        c = '0';
+      } else {
+        c = ' ';
+      }
+      while ((FieldWidth != 0u) && (Width < FieldWidth)) {
+        FieldWidth--;
+        _StoreChar(pBufferDesc, c);
+        if (pBufferDesc->ReturnValue < 0) {
+          break;
+        }
+      }
+    }
+  }
+  if (pBufferDesc->ReturnValue >= 0) {
+    //
+    // Compute Digit.
+    // Loop until Digit has the value of the highest digit required.
+    // Example: If the output is 345 (Base 10), loop 2 times until Digit is 100.
+    //
+    while (1) {
+      if (NumDigits > 1u) {       // User specified a min number of digits to print? => Make sure we loop at least that often, before checking anything else (> 1 check avoids problems with NumDigits being signed / unsigned)
+        NumDigits--;
+      } else {
+        Div = v / Digit;
+        if (Div < Base) {        // Is our divider big enough to extract the highest digit from value? => Done
+          break;
+        }
+      }
+      Digit *= Base;
+    }
+    //
+    // Output digits
+    //
+    do {
+      Div = v / Digit;
+      v -= Div * Digit;
+      _StoreChar(pBufferDesc, _aV2C[Div]);
+      if (pBufferDesc->ReturnValue < 0) {
+        break;
+      }
+      Digit /= Base;
+    } while (Digit);
+    //
+    // Print trailing spaces if necessary
+    //
+    if ((FormatFlags & FORMAT_FLAG_LEFT_JUSTIFY) == FORMAT_FLAG_LEFT_JUSTIFY) {
+      if (FieldWidth != 0u) {
+        while ((FieldWidth != 0u) && (Width < FieldWidth)) {
+          FieldWidth--;
+          _StoreChar(pBufferDesc, ' ');
+          if (pBufferDesc->ReturnValue < 0) {
+            break;
+          }
+        }
+      }
+    }
+  }
+}
+
+/*********************************************************************
+*
+*       _PrintInt
+*/
+static void _PrintInt(SEGGER_RTT_PRINTF_DESC * pBufferDesc, int v, unsigned Base, unsigned NumDigits, unsigned FieldWidth, unsigned FormatFlags) {
+  unsigned Width;
+  int Number;
+
+  Number = (v < 0) ? -v : v;
+
+  //
+  // Get actual field width
+  //
+  Width = 1u;
+  while (Number >= (int)Base) {
+    Number = (Number / (int)Base);
+    Width++;
+  }
+  if (NumDigits > Width) {
+    Width = NumDigits;
+  }
+  if ((FieldWidth > 0u) && ((v < 0) || ((FormatFlags & FORMAT_FLAG_PRINT_SIGN) == FORMAT_FLAG_PRINT_SIGN))) {
+    FieldWidth--;
+  }
+
+  //
+  // Print leading spaces if necessary
+  //
+  if ((((FormatFlags & FORMAT_FLAG_PAD_ZERO) == 0u) || (NumDigits != 0u)) && ((FormatFlags & FORMAT_FLAG_LEFT_JUSTIFY) == 0u)) {
+    if (FieldWidth != 0u) {
+      while ((FieldWidth != 0u) && (Width < FieldWidth)) {
+        FieldWidth--;
+        _StoreChar(pBufferDesc, ' ');
+        if (pBufferDesc->ReturnValue < 0) {
+          break;
+        }
+      }
+    }
+  }
+  //
+  // Print sign if necessary
+  //
+  if (pBufferDesc->ReturnValue >= 0) {
+    if (v < 0) {
+      v = -v;
+      _StoreChar(pBufferDesc, '-');
+    } else if ((FormatFlags & FORMAT_FLAG_PRINT_SIGN) == FORMAT_FLAG_PRINT_SIGN) {
+      _StoreChar(pBufferDesc, '+');
+    } else {
+
+    }
+    if (pBufferDesc->ReturnValue >= 0) {
+      //
+      // Print leading zeros if necessary
+      //
+      if (((FormatFlags & FORMAT_FLAG_PAD_ZERO) == FORMAT_FLAG_PAD_ZERO) && ((FormatFlags & FORMAT_FLAG_LEFT_JUSTIFY) == 0u) && (NumDigits == 0u)) {
+        if (FieldWidth != 0u) {
+          while ((FieldWidth != 0u) && (Width < FieldWidth)) {
+            FieldWidth--;
+            _StoreChar(pBufferDesc, '0');
+            if (pBufferDesc->ReturnValue < 0) {
+              break;
+            }
+          }
+        }
+      }
+      if (pBufferDesc->ReturnValue >= 0) {
+        //
+        // Print number without sign
+        //
+        _PrintUnsigned(pBufferDesc, (unsigned)v, Base, NumDigits, FieldWidth, FormatFlags);
+      }
+    }
+  }
+}
+
+/*********************************************************************
+*
+*       Public code
+*
+**********************************************************************
+*/
+/*********************************************************************
+*
+*       SEGGER_RTT_vprintf
+*
+*  Function description
+*    Stores a formatted string in SEGGER RTT control block.
+*    This data is read by the host.
+*
+*  Parameters
+*    BufferIndex  Index of "Up"-buffer to be used. (e.g. 0 for "Terminal")
+*    sFormat      Pointer to format string
+*    pParamList   Pointer to the list of arguments for the format string
+*
+*  Return values
+*    >= 0:  Number of bytes which have been stored in the "Up"-buffer.
+*     < 0:  Error
+*/
+int SEGGER_RTT_vprintf(unsigned BufferIndex, const char * sFormat, va_list * pParamList) {
+  char c;
+  SEGGER_RTT_PRINTF_DESC BufferDesc;
+  int v;
+  unsigned NumDigits;
+  unsigned FormatFlags;
+  unsigned FieldWidth;
+  char acBuffer[SEGGER_RTT_PRINTF_BUFFER_SIZE];
+
+  BufferDesc.pBuffer        = acBuffer;
+  BufferDesc.BufferSize     = SEGGER_RTT_PRINTF_BUFFER_SIZE;
+  BufferDesc.Cnt            = 0u;
+  BufferDesc.RTTBufferIndex = BufferIndex;
+  BufferDesc.ReturnValue    = 0;
+
+  do {
+    c = *sFormat;
+    sFormat++;
+    if (c == 0u) {
+      break;
+    }
+    if (c == '%') {
+      //
+      // Filter out flags
+      //
+      FormatFlags = 0u;
+      v = 1;
+      do {
+        c = *sFormat;
+        switch (c) {
+        case '-': FormatFlags |= FORMAT_FLAG_LEFT_JUSTIFY; sFormat++; break;
+        case '0': FormatFlags |= FORMAT_FLAG_PAD_ZERO;     sFormat++; break;
+        case '+': FormatFlags |= FORMAT_FLAG_PRINT_SIGN;   sFormat++; break;
+        case '#': FormatFlags |= FORMAT_FLAG_ALTERNATE;    sFormat++; break;
+        default:  v = 0; break;
+        }
+      } while (v);
+      //
+      // filter out field with
+      //
+      FieldWidth = 0u;
+      do {
+        c = *sFormat;
+        if ((c < '0') || (c > '9')) {
+          break;
+        }
+        sFormat++;
+        FieldWidth = (FieldWidth * 10u) + ((unsigned)c - '0');
+      } while (1);
+
+      //
+      // Filter out precision (number of digits to display)
+      //
+      NumDigits = 0u;
+      c = *sFormat;
+      if (c == '.') {
+        sFormat++;
+        do {
+          c = *sFormat;
+          if ((c < '0') || (c > '9')) {
+            break;
+          }
+          sFormat++;
+          NumDigits = NumDigits * 10u + ((unsigned)c - '0');
+        } while (1);
+      }
+      //
+      // Filter out length modifier
+      //
+      c = *sFormat;
+      do {
+        if ((c == 'l') || (c == 'h')) {
+          sFormat++;
+          c = *sFormat;
+        } else {
+          break;
+        }
+      } while (1);
+      //
+      // Handle specifiers
+      //
+      switch (c) {
+      case 'c': {
+        char c0;
+        v = va_arg(*pParamList, int);
+        c0 = (char)v;
+        _StoreChar(&BufferDesc, c0);
+        break;
+      }
+      case 'd':
+        v = va_arg(*pParamList, int);
+        _PrintInt(&BufferDesc, v, 10u, NumDigits, FieldWidth, FormatFlags);
+        break;
+      case 'u':
+        v = va_arg(*pParamList, int);
+        _PrintUnsigned(&BufferDesc, (unsigned)v, 10u, NumDigits, FieldWidth, FormatFlags);
+        break;
+      case 'x':
+      case 'X':
+        v = va_arg(*pParamList, int);
+        _PrintUnsigned(&BufferDesc, (unsigned)v, 16u, NumDigits, FieldWidth, FormatFlags);
+        break;
+      case 's':
+        {
+          const char * s = va_arg(*pParamList, const char *);
+          do {
+            c = *s;
+            s++;
+            if (c == '\0') {
+              break;
+            }
+           _StoreChar(&BufferDesc, c);
+          } while (BufferDesc.ReturnValue >= 0);
+        }
+        break;
+      case 'p':
+        v = va_arg(*pParamList, int);
+        _PrintUnsigned(&BufferDesc, (unsigned)v, 16u, 8u, 8u, 0u);
+        break;
+      case '%':
+        _StoreChar(&BufferDesc, '%');
+        break;
+      default:
+        break;
+      }
+      sFormat++;
+    } else {
+      _StoreChar(&BufferDesc, c);
+    }
+  } while (BufferDesc.ReturnValue >= 0);
+
+  if (BufferDesc.ReturnValue > 0) {
+    //
+    // Write remaining data, if any
+    //
+    if (BufferDesc.Cnt != 0u) {
+      SEGGER_RTT_Write(BufferIndex, acBuffer, BufferDesc.Cnt);
+    }
+    BufferDesc.ReturnValue += (int)BufferDesc.Cnt;
+  }
+  return BufferDesc.ReturnValue;
+}
+
+/*********************************************************************
+*
+*       SEGGER_RTT_printf
+*
+*  Function description
+*    Stores a formatted string in SEGGER RTT control block.
+*    This data is read by the host.
+*
+*  Parameters
+*    BufferIndex  Index of "Up"-buffer to be used. (e.g. 0 for "Terminal")
+*    sFormat      Pointer to format string, followed by the arguments for conversion
+*
+*  Return values
+*    >= 0:  Number of bytes which have been stored in the "Up"-buffer.
+*     < 0:  Error
+*
+*  Notes
+*    (1) Conversion specifications have following syntax:
+*          %[flags][FieldWidth][.Precision]ConversionSpecifier
+*    (2) Supported flags:
+*          -: Left justify within the field width
+*          +: Always print sign extension for signed conversions
+*          0: Pad with 0 instead of spaces. Ignored when using '-'-flag or precision
+*        Supported conversion specifiers:
+*          c: Print the argument as one char
+*          d: Print the argument as a signed integer
+*          u: Print the argument as an unsigned integer
+*          x: Print the argument as an hexadecimal integer
+*          s: Print the string pointed to by the argument
+*          p: Print the argument as an 8-digit hexadecimal integer. (Argument shall be a pointer to void.)
+*/
+int SEGGER_RTT_printf(unsigned BufferIndex, const char * sFormat, ...) {
+  int r;
+  va_list ParamList;
+
+  va_start(ParamList, sFormat);
+  r = SEGGER_RTT_vprintf(BufferIndex, sFormat, &ParamList);
+  va_end(ParamList);
+  return r;
+}
+/*************************** End of file ****************************/

--- a/tests/unit/test_structs.py
+++ b/tests/unit/test_structs.py
@@ -400,6 +400,70 @@ class TestStructs(unittest.TestCase):
         self.assertEqual(rep, str(region))
         self.assertEqual(rep, repr(region))
 
+    def test_jlink_rtt_terminal_start(self):
+        """Tests the ``JLinkRTTerminalStart`` structure.
+
+        Args:
+          self (TestStructs): the ``TestStructs`` instance
+
+        Returns:
+          ``None``
+        """
+        start = structs.JLinkRTTerminalStart()
+        rep = 'JLinkRTTerminalStart(ConfigAddress=0x0)'
+        self.assertEqual(rep, repr(start))
+
+        start.ConfigBlockAddress = 0xDEADBEEF
+        rep = 'JLinkRTTerminalStart(ConfigAddress=0xDEADBEEF)'
+        self.assertEqual(rep, str(start))
+
+    def test_jlink_rtt_terminal_buf_desc(self):
+        """Tests the ``JLinkRTTerminalBufDesc`` structure.
+
+        Args:
+          self (TestStructs): the ``TestStructs`` instance
+
+        Returns:
+          ``None``
+        """
+        desc = structs.JLinkRTTerminalBufDesc()
+        desc.BufferIndex = 7
+        desc.SizeOfBuffer = 1337
+        desc.Flags = 0
+        desc.acName = str.encode('The Winds of Winter')
+
+        desc.Direction = 0
+        self.assertTrue(desc.up)
+        self.assertFalse(desc.down)
+
+        desc.Direction = 1
+        self.assertTrue(desc.down)
+        self.assertFalse(desc.up)
+
+        self.assertEqual('The Winds of Winter', desc.name)
+        self.assertEqual('JLinkRTTerminalBufDesc(Index=7, Name=The Winds of Winter)', repr(desc))
+        self.assertEqual('The Winds of Winter <Index=7, Direction=down, Size=1337>', str(desc))
+
+        desc.Direction = 0
+        self.assertEqual('The Winds of Winter <Index=7, Direction=up, Size=1337>', str(desc))
+
+    def test_jlink_rtt_terminal_stat(self):
+        """Tests the ``JLinkRTTerminalStatus`` structure.
+
+        Args:
+          self (TestStructs): the ``TestStructs`` instance
+
+        Returns:
+          ``None``
+        """
+        stat = structs.JLinkRTTerminalStatus()
+        stat.NumUpBuffers = 3
+        stat.NumDownBuffers = 3
+        stat.IsRunning = 1
+
+        self.assertEqual('JLinkRTTerminalStatus(NumUpBuffers=3, NumDownBuffers=3)', repr(stat))
+        self.assertEqual('Status <NumUpBuffers=3, NumDownBuffers=3, Running=1>', str(stat))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Feature: RTT Control Buffer and Status
### Description
This PR fleshes out the RTT support to resolve #48 and #51.  Specifically, this PR adds the ability to pass an address for the RTT control block when starting RTT, get the current RTT status (including number of up and down buffers), and get the descriptor for an RTT buffer (which returns information such as the name of the buffer, and the size of the buffer).

### Testing
A new firmware image has been added that builds in the RTT vendor code and implements a simple echo program.  The firmware reads a single byte from an RTT down buffer and writes that byte to the RTT up buffer; both on channel 0.  The associated functional test attempts to write a string over RTT on the host, then read said string back from the device.  This has been tested and verified on an evaluation board.

CC @charlesnicholson, as original RTT support adder.