### PR TITLE
Fix VTarget behaviour

### DIFF
--- a/pylink/structs.py
+++ b/pylink/structs.py
@@ -242,7 +242,7 @@ class JLinkHardwareStatus(ctypes.Structure):
       trst: measured state of TRST pin.
     """
     _fields_ = [
-        ('VTarget', ctypes.c_uint32),
+        ('VTarget', ctypes.c_uint16),
         ('tck', ctypes.c_uint8),
         ('tdi', ctypes.c_uint8),
         ('tdo', ctypes.c_uint8),
@@ -260,7 +260,7 @@ class JLinkHardwareStatus(ctypes.Structure):
         Returns:
           String representation of the instance.
         """
-        return '%s(VTarget=%dmA)' % (self.__class__.__name__, self.voltage)
+        return '%s(VTarget=%dmV)' % (self.__class__.__name__, self.voltage)
 
     @property
     def voltage(self):

--- a/tests/unit/test_structs.py
+++ b/tests/unit/test_structs.py
@@ -141,8 +141,8 @@ class TestStructs(unittest.TestCase):
         status = structs.JLinkHardwareStatus()
         status.VTarget = voltage
         self.assertEqual(voltage, status.voltage)
-        self.assertEqual('JLinkHardwareStatus(VTarget=100mA)', str(status))
-        self.assertEqual('JLinkHardwareStatus(VTarget=100mA)', repr(status))
+        self.assertEqual('JLinkHardwareStatus(VTarget=100mV)', str(status))
+        self.assertEqual('JLinkHardwareStatus(VTarget=100mV)', repr(status))
 
     def test_jlink_gpio_descriptor(self):
         """Tests the ``JLinkGPIODescriptor`` structure.


### PR DESCRIPTION
* Changed displayed units from mA to mV.
* Fix units - voltage seems to be a `uint16_t` / the high bits are used for something else. 

Tested on `DLL version V6.46d, compiled Jun  7 2019 17:33:40` on Windows 10 x64.  

Have now signed the contributor agreement.