### PR TITLE
Protect against multiple calls to JLINKARM_Close

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -722,8 +722,8 @@ class JLink(object):
           JLinkException: if there is no connected JLink.
         """
         if self._jlink_open:
-          self._dll.JLINKARM_Close()
-          self._jlink_open = False
+            self._dll.JLINKARM_Close()
+            self._jlink_open = False
 
         if self._lock is not None:
             del self._lock

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -274,6 +274,7 @@ class JLink(object):
         self._swo_enabled = False
         self._lock = None
         self._device = None
+        self._jlink_open = False
 
         # Bind Types for function calls.
         self._dll.JLINKARM_OpenEx.restype = ctypes.POINTER(ctypes.c_char)
@@ -692,6 +693,7 @@ class JLink(object):
             func = enums.JLinkFunctions.UNSECURE_HOOK_PROTOTYPE(unsecure_hook)
             self._dll.JLINK_SetHookUnsecureDialog(func)
 
+        self._jlink_open = True
         return None
 
     def open_tunnel(self, serial_no, port=19020):
@@ -719,7 +721,9 @@ class JLink(object):
         Raises:
           JLinkException: if there is no connected JLink.
         """
-        self._dll.JLINKARM_Close()
+        if self._jlink_open:
+          self._dll.JLINKARM_Close()
+          self._jlink_open = False
 
         if self._lock is not None:
             del self._lock

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -947,10 +947,11 @@ class TestJLink(unittest.TestCase):
         Returns:
           ``None``
         """
-        self.dll.JLINKARM_OpenEx.return_value = 0
-        with jlink.JLink(self.lib, serial_no=123456789) as jl:
-            self.assertTrue(jl.opened())  # Opened in CM.
+        # Use open_tunnel=None to avoid implicitly opening the connection.
+        with jlink.JLink(self.lib, open_tunnel=None) as jl:
             self.dll.JLINKARM_Close.assert_not_called()
+            # Bump the refcount without calling .open().
+            jl._open_refcount = 1
         # .close() is first called when exiting the context manager
         # Depending on the system - GC operation, it can also already be
         # called from __del__ when the object is garbage collected.

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -924,17 +924,18 @@ class TestJLink(unittest.TestCase):
         # close() does nothing if there has been no open() call first.
         self.jlink.close()
         self.assertEqual(0, self.dll.JLINKARM_Close.call_count)
+
         # close() decrements the refcount if open() has been called multiple times.
         self.jlink._open_refcount = 5
         self.jlink.close()
         self.assertEqual(0, self.dll.JLINKARM_Close.call_count)
         self.assertEqual(4, self.jlink._open_refcount)
+
         # close() calls the DLL close method when refcount is exhausted.
         self.jlink._open_refcount = 1
         self.jlink.close()
         self.assertEqual(1, self.dll.JLINKARM_Close.call_count)
         self.assertEqual(0, self.jlink._open_refcount)
-
 
     def test_jlink_close_context_manager(self):
         """Tests the J-Link ``close()`` method using context manager.
@@ -945,11 +946,11 @@ class TestJLink(unittest.TestCase):
         Returns:
           ``None``
         """
-        # Use open_tunnel=None to avoid implicitly opening the connection.
-        with jlink.JLink(self.lib, open_tunnel=None) as jl:
+        self.dll.JLINKARM_OpenEx.return_value = 0
+        with jlink.JLink(self.lib, ip_addr='127.0.0.1:80') as jl:
+            self.assertTrue(jl.opened())
             self.dll.JLINKARM_Close.assert_not_called()
-            # Bump the refcount without calling .open().
-            jl._open_refcount = 1
+
         # .close() is first called when exiting the context manager
         # Depending on the system - GC operation, it can also already be
         # called from __del__ when the object is garbage collected.

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -924,13 +924,11 @@ class TestJLink(unittest.TestCase):
         # close() does nothing if there has been no open() call first.
         self.jlink.close()
         self.assertEqual(0, self.dll.JLINKARM_Close.call_count)
-
         # close() decrements the refcount if open() has been called multiple times.
         self.jlink._open_refcount = 5
         self.jlink.close()
         self.assertEqual(0, self.dll.JLINKARM_Close.call_count)
         self.assertEqual(4, self.jlink._open_refcount)
-
         # close() calls the DLL close method when refcount is exhausted.
         self.jlink._open_refcount = 1
         self.jlink.close()


### PR DESCRIPTION
With the latest JLink DLLs (tested with 6.56b), calling jlink.close()
twice can crash. This is a problem because there is an uncoditional call
to close() inside jlink.open(). Any code that attempts to cycle a jlink
connection by calling .close() followed by .open() therefore hits a
double close and the corresponding crash.

Crash from inside JLINKARM_Close looks like:
`double free or corruption (out)`