### PR TITLE
Fix unsecure hook problem

### DIFF
--- a/pylink/enums.py
+++ b/pylink/enums.py
@@ -322,9 +322,7 @@ class JLinkFunctions(object):
     """Collection of function prototype and type builders for the J-Link SDK
     API calls."""
     LOG_PROTOTYPE = ctypes.CFUNCTYPE(None, ctypes.c_char_p)
-    """UNSECURE_HOOK_PROTOTYPE is used for JLINK_SetHookUnsecureDialog which is stdcall,
-    so we should use WINFUNCTYPE here."""
-    UNSECURE_HOOK_PROTOTYPE = ctypes.WINFUNCTYPE(ctypes.c_int,
+    UNSECURE_HOOK_PROTOTYPE = ctypes.CFUNCTYPE(ctypes.c_int,
                                                ctypes.c_char_p,
                                                ctypes.c_char_p,
                                                ctypes.c_uint32)

--- a/pylink/enums.py
+++ b/pylink/enums.py
@@ -322,7 +322,9 @@ class JLinkFunctions(object):
     """Collection of function prototype and type builders for the J-Link SDK
     API calls."""
     LOG_PROTOTYPE = ctypes.CFUNCTYPE(None, ctypes.c_char_p)
-    UNSECURE_HOOK_PROTOTYPE = ctypes.CFUNCTYPE(ctypes.c_int,
+    """UNSECURE_HOOK_PROTOTYPE is used for JLINK_SetHookUnsecureDialog which is stdcall,
+    so we should use WINFUNCTYPE here."""
+    UNSECURE_HOOK_PROTOTYPE = ctypes.WINFUNCTYPE(ctypes.c_int,
                                                ctypes.c_char_p,
                                                ctypes.c_char_p,
                                                ctypes.c_uint32)

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -696,8 +696,8 @@ class JLink(object):
         # on versions greater than V4.98a.
         unsecure_hook = self._unsecure_hook
         if unsecure_hook is not None and hasattr(self._dll, 'JLINK_SetHookUnsecureDialog'):
-            func = enums.JLinkFunctions.UNSECURE_HOOK_PROTOTYPE(unsecure_hook)
-            self._dll.JLINK_SetHookUnsecureDialog(func)
+            self.unsecure_hook = enums.JLinkFunctions.UNSECURE_HOOK_PROTOTYPE(unsecure_hook)
+            self._dll.JLINK_SetHookUnsecureDialog(self.unsecure_hook)
 
         self._open_refcount = 1
         return None


### PR DESCRIPTION
1、It looks like the local object "func" is deleted after `self._dll.JLINK_SetHookUnsecureDialog`