### PR TITLE
Set maximum interface speed to 100 MHz

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -52,7 +52,7 @@ class JLink(object):
     MAX_NUM_CPU_REGISTERS = 256
 
     # Maximum speed (in kHz) that can be passed to `set_speed()`.
-    MAX_JTAG_SPEED = 12000
+    MAX_JTAG_SPEED = 50000
 
     # Minimum speed (in kHz) that can be passed to `set_speed()`.
     MIN_JTAG_SPEED = 5


### PR DESCRIPTION
Maximum interface speeds of up to 100 MHz are supported by J-Link (see
https://www.segger.com/products/debug-probes/j-link/models/model-overview/).
If a J-Link does not supported a speed, it will returned an error.
Verified to work with 100 MHz on J-Link Ultra+.