### PR TITLE
Improved speed and efficiency of `connect`

### DIFF
--- a/pylink/__main__.py
+++ b/pylink/__main__.py
@@ -440,20 +440,21 @@ class EmulatorCommand(Command):
                     print('IP Address: %s' % emulator.aIPAddr)
         elif args.supported is not None:
             device = args.supported[0]
-            num_supported_devices = jlink.num_supported_devices()
-            for i in range(num_supported_devices):
-                found_device = jlink.supported_device(i)
-                if device.lower() == found_device.name.lower():
-                    print('Device Name: %s' % device)
-                    print('Core ID: %s' % found_device.CoreId)
-                    print('Flash Address: %s' % found_device.FlashAddr)
-                    print('Flash Size: %s bytes' % found_device.FlashSize)
-                    print('RAM Address: %s' % found_device.RAMAddr)
-                    print('RAM Size: %s bytes' % found_device.RAMSize)
-                    print('Manufacturer: %s' % found_device.manufacturer)
-                    break
-            else:
+            try:
+                index = jlink.get_device_index(device)
+            except pylink.errors.JLinkException:
                 print('%s is not supported :(' % device)
+                return None
+
+            found_device = jlink.supported_device(index)
+
+            print('Device Name: %s' % device)
+            print('Core ID: %s' % found_device.CoreId)
+            print('Flash Address: %s' % found_device.FlashAddr)
+            print('Flash Size: %s bytes' % found_device.FlashSize)
+            print('RAM Address: %s' % found_device.RAMAddr)
+            print('RAM Size: %s bytes' % found_device.RAMSize)
+            print('Manufacturer: %s' % found_device.manufacturer)
 
         return None
 

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -624,6 +624,24 @@ class JLink(object):
 
         return list(info)[:num_found]
 
+    def get_device_index(self, chip_name):
+        """Finds index of device with chip name
+
+        Args:
+          self (JLink): the ``JLink`` instance
+          chip_name (str): target chip name
+
+        Returns:
+          Index of the device with the matching chip name.
+          If the chip is unsupported, returns ``<=0``.
+        """
+        index = self._dll.JLINKARM_DEVICE_GetIndex(chip_name.encode('ascii'))
+
+        if index <= 0:
+            raise errors.JLinkException('Unsupported device selected.')
+
+        return index
+
     def num_supported_devices(self):
         """Returns the number of devices that are supported by the opened
         J-Link DLL.
@@ -1068,10 +1086,7 @@ class JLink(object):
 
         # Determine which device we are.  This is essential for using methods
         # like 'unlock' or 'lock'.
-        index = self._dll.JLINKARM_DEVICE_GetIndex(chip_name.encode('ascii'))
-
-        if index <= 0:
-            raise errors.JLinkException('Unsupported device selected.')
+        index = self.get_device_index(chip_name)
 
         self._device = self.supported_device(index)
 

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -1066,6 +1066,15 @@ class JLink(object):
         if verbose:
             self.exec_command('EnableRemarks = 1')
 
+        # Determine which device we are.  This is essential for using methods
+        # like 'unlock' or 'lock'.
+        index = self._dll.JLINKARM_DEVICE_GetIndex(chip_name.encode('ascii'))
+
+        if index <= 0:
+            raise errors.JLinkException('Unsupported device selected.')
+
+        self._device = self.supported_device(index)
+
         # This is weird but is currently the only way to specify what the
         # target is to the J-Link.
         self.exec_command('Device = %s' % chip_name)
@@ -1088,16 +1097,6 @@ class JLink(object):
             self.halted()
         except errors.JLinkException:
             pass
-
-        # Determine which device we are.  This is essential for using methods
-        # like 'unlock' or 'lock'.
-        for index in range(self.num_supported_devices()):
-            device = self.supported_device(index)
-            if device.name.lower() == chip_name.lower():
-                self._device = device
-                break
-        else:
-            raise errors.JLinkException('Unsupported device was connected to.')
 
         return None
 

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -633,7 +633,9 @@ class JLink(object):
 
         Returns:
           Index of the device with the matching chip name.
-          If the chip is unsupported, returns ``<=0``.
+
+        Raises:
+          ``JLinkException``: if chip is unsupported.
         """
         index = self._dll.JLINKARM_DEVICE_GetIndex(chip_name.encode('ascii'))
 

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -502,6 +502,22 @@ class TestJLink(unittest.TestCase):
         self.assertEqual(1, len(connected_emulators))
         self.assertTrue(isinstance(connected_emulators[0], structs.JLinkConnectInfo))
 
+    def test_jlink_get_device_index(self):
+        """Tests the J-Link ``get_device_index()`` method.
+
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        self.dll.JLINKARM_DEVICE_GetIndex.return_value = 1
+        self.assertEqual(self.jlink.get_device_index("device"), 1)
+
+        self.dll.JLINKARM_DEVICE_GetIndex.return_value = 0
+        with self.assertRaises(JLinkException):
+            self.jlink.get_device_index("device")
+
     def test_jlink_num_supported_devices(self):
         """Tests the J-Link ``num_supported_devices()`` method.
 

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -1267,6 +1267,11 @@ class TestJLink(unittest.TestCase):
         self.dll.JLINKARM_ExecCommand.return_value = 0
         self.dll.JLINKARM_Connect.return_value = -1
         self.dll.JLINKARM_IsHalted.return_value = 0
+        self.dll.JLINKARM_DEVICE_GetIndex.return_value = 1
+
+        self.jlink.supported_device = mock.Mock()
+        self.jlink.supported_device.return_value = mock.Mock()
+        self.jlink.supported_device.return_value.name = 'device'
 
         with self.assertRaises(JLinkException):
             self.jlink.connect('device')
@@ -1274,6 +1279,7 @@ class TestJLink(unittest.TestCase):
         self.assertEqual(1, self.dll.JLINKARM_ExecCommand.call_count)
         self.assertEqual(1, self.dll.JLINKARM_Connect.call_count)
         self.assertEqual(0, self.dll.JLINKARM_IsHalted.call_count)
+        self.assertEqual(1, self.dll.JLINKARM_DEVICE_GetIndex.call_count)
 
     @mock.patch('time.sleep')
     def test_jlink_connect_auto(self, mock_sleep):
@@ -1289,9 +1295,8 @@ class TestJLink(unittest.TestCase):
         self.dll.JLINKARM_ExecCommand.return_value = 0
         self.dll.JLINKARM_Connect.return_value = 0
         self.dll.JLINKARM_IsHalted.return_value = 0
+        self.dll.JLINKARM_DEVICE_GetIndex.return_value = 1
 
-        self.jlink.num_supported_devices = mock.Mock()
-        self.jlink.num_supported_devices.return_value = 1
         self.jlink.supported_device = mock.Mock()
         self.jlink.supported_device.return_value = mock.Mock()
         self.jlink.supported_device.return_value.name = 'device'
@@ -1301,6 +1306,7 @@ class TestJLink(unittest.TestCase):
         self.assertEqual(1, self.dll.JLINKARM_ExecCommand.call_count)
         self.assertEqual(1, self.dll.JLINKARM_Connect.call_count)
         self.assertEqual(1, self.dll.JLINKARM_IsHalted.call_count)
+        self.assertEqual(1, self.dll.JLINKARM_DEVICE_GetIndex.call_count)
 
     @mock.patch('time.sleep')
     def test_jlink_connect_adaptive(self, mock_sleep):
@@ -1316,9 +1322,8 @@ class TestJLink(unittest.TestCase):
         self.dll.JLINKARM_ExecCommand.return_value = 0
         self.dll.JLINKARM_Connect.return_value = 0
         self.dll.JLINKARM_IsHalted.return_value = 0
+        self.dll.JLINKARM_DEVICE_GetIndex.return_value = 1
 
-        self.jlink.num_supported_devices = mock.Mock()
-        self.jlink.num_supported_devices.return_value = 1
         self.jlink.supported_device = mock.Mock()
         self.jlink.supported_device.return_value = mock.Mock()
         self.jlink.supported_device.return_value.name = 'device'
@@ -1328,6 +1333,7 @@ class TestJLink(unittest.TestCase):
         self.assertEqual(1, self.dll.JLINKARM_ExecCommand.call_count)
         self.assertEqual(1, self.dll.JLINKARM_Connect.call_count)
         self.assertEqual(1, self.dll.JLINKARM_IsHalted.call_count)
+        self.assertEqual(1, self.dll.JLINKARM_DEVICE_GetIndex.call_count)
 
     @mock.patch('time.sleep')
     def test_jlink_connect_speed_invalid(self, mock_sleep):
@@ -1343,6 +1349,11 @@ class TestJLink(unittest.TestCase):
         self.dll.JLINKARM_ExecCommand.return_value = 0
         self.dll.JLINKARM_Connect.return_value = 0
         self.dll.JLINKARM_IsHalted.return_value = 0
+        self.dll.JLINKARM_DEVICE_GetIndex.return_value = 1
+
+        self.jlink.supported_device = mock.Mock()
+        self.jlink.supported_device.return_value = mock.Mock()
+        self.jlink.supported_device.return_value.name = 'device'
 
         with self.assertRaises(TypeError):
             self.jlink.connect('device', speed=-1)
@@ -1350,6 +1361,7 @@ class TestJLink(unittest.TestCase):
         self.assertEqual(1, self.dll.JLINKARM_ExecCommand.call_count)
         self.assertEqual(0, self.dll.JLINKARM_Connect.call_count)
         self.assertEqual(0, self.dll.JLINKARM_IsHalted.call_count)
+        self.assertEqual(1, self.dll.JLINKARM_DEVICE_GetIndex.call_count)
 
     @mock.patch('time.sleep')
     def test_jlink_connect_speed(self, mock_sleep):
@@ -1365,9 +1377,8 @@ class TestJLink(unittest.TestCase):
         self.dll.JLINKARM_ExecCommand.return_value = 0
         self.dll.JLINKARM_Connect.return_value = 0
         self.dll.JLINKARM_IsHalted.return_value = 0
+        self.dll.JLINKARM_DEVICE_GetIndex.return_value = 1
 
-        self.jlink.num_supported_devices = mock.Mock()
-        self.jlink.num_supported_devices.return_value = 1
         self.jlink.supported_device = mock.Mock()
         self.jlink.supported_device.return_value = mock.Mock()
         self.jlink.supported_device.return_value.name = 'device'
@@ -1377,6 +1388,7 @@ class TestJLink(unittest.TestCase):
         self.assertEqual(1, self.dll.JLINKARM_ExecCommand.call_count)
         self.assertEqual(1, self.dll.JLINKARM_Connect.call_count)
         self.assertEqual(1, self.dll.JLINKARM_IsHalted.call_count)
+        self.assertEqual(1, self.dll.JLINKARM_DEVICE_GetIndex.call_count)
 
     @mock.patch('time.sleep')
     def test_jlink_connect_verbose(self, mock_sleep):
@@ -1392,9 +1404,8 @@ class TestJLink(unittest.TestCase):
         self.dll.JLINKARM_ExecCommand.return_value = 0
         self.dll.JLINKARM_Connect.return_value = 0
         self.dll.JLINKARM_IsHalted.return_value = 0
+        self.dll.JLINKARM_DEVICE_GetIndex.return_value = 1
 
-        self.jlink.num_supported_devices = mock.Mock()
-        self.jlink.num_supported_devices.return_value = 1
         self.jlink.supported_device = mock.Mock()
         self.jlink.supported_device.return_value = mock.Mock()
         self.jlink.supported_device.return_value.name = 'device'
@@ -1404,6 +1415,7 @@ class TestJLink(unittest.TestCase):
         self.assertEqual(2, self.dll.JLINKARM_ExecCommand.call_count)
         self.assertEqual(1, self.dll.JLINKARM_Connect.call_count)
         self.assertEqual(1, self.dll.JLINKARM_IsHalted.call_count)
+        self.assertEqual(1, self.dll.JLINKARM_DEVICE_GetIndex.call_count)
 
     @mock.patch('time.sleep')
     def test_jlink_connect_supported_device_not_found(self, mock_sleep):
@@ -1419,12 +1431,15 @@ class TestJLink(unittest.TestCase):
         self.dll.JLINKARM_ExecCommand.return_value = 0
         self.dll.JLINKARM_Connect.return_value = 0
         self.dll.JLINKARM_IsHalted.return_value = 0
-
-        self.jlink.num_supported_devices = mock.Mock()
-        self.jlink.num_supported_devices.return_value = 0
+        self.dll.JLINKARM_DEVICE_GetIndex.return_value = -1
 
         with self.assertRaisesRegexp(JLinkException, 'Unsupported device'):
             self.jlink.connect('device')
+
+        self.assertEqual(0, self.dll.JLINKARM_ExecCommand.call_count)
+        self.assertEqual(0, self.dll.JLINKARM_Connect.call_count)
+        self.assertEqual(0, self.dll.JLINKARM_IsHalted.call_count)
+        self.assertEqual(1, self.dll.JLINKARM_DEVICE_GetIndex.call_count)
 
     def test_jlink_error(self):
         """Tests the J-Link ``error`` property.

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -348,8 +348,7 @@ class TestMain(unittest.TestCase):
         device = pylink.JLinkDeviceInfo()
         device.sName = name
 
-        mocked.num_supported_devices.return_value = 1
-        mocked.supported_device.return_value = device
+        mocked.get_device_index.side_effect = pylink.errors.JLinkException('Unsupported device selected.')
 
         args = ['emulator', '-s', 'USA']
         self.assertEqual(0, main.main(args))
@@ -357,6 +356,10 @@ class TestMain(unittest.TestCase):
 
         mock_stdout.truncate(0)
         mock_stdout.seek(0)
+
+        mocked.get_device_index.side_effect = None
+        mocked.get_device_index.return_value = 1
+        mocked.supported_device.return_value = device
 
         args = ['emulator', '-s', 'CANADA']
         self.assertEqual(0, main.main(args))


### PR DESCRIPTION
JLink has a neat little function that can save us iterating over all the devices.

If the device is unsupported, the API returns -1:

