### PR TITLE
Reduce CPU usage of rtt_read

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -5016,7 +5016,7 @@ class JLink(object):
         if bytes_read < 0:
             raise errors.JLinkRTTException(bytes_read)
 
-        return list(buf)[:bytes_read]
+        return list(buf[:bytes_read])
 
     @open_required
     def rtt_write(self, buffer_index, data):


### PR DESCRIPTION
Get valid data from buf before converting it to list.

I have an RTT about 200kB/s and do rtt_read every 100ms with 128KB buffer. The CPU usage is reduced from 3% to below 0.5% on an 8C/16T machine.