### PR TITLE
Use temp dir accessor instead of cache variable

### DIFF
--- a/pylink/jlock.py
+++ b/pylink/jlock.py
@@ -65,7 +65,7 @@ class JLock(object):
         self.acquired = False
         self.fd = None
         self.path = None
-        self.path = os.path.join(tempfile.tempdir, self.name)
+        self.path = os.path.join(tempfile.gettempdir(), self.name)
 
     def __del__(self):
         """Cleans up the lockfile instance if it was acquired.


### PR DESCRIPTION
`tempfile.tempdir` is not set until `tempfile.gettempdir()` is called. This results in lock files being placed in the current working directory instead of a shared location.