### PR TITLE
Fixed issue when Pylink requires target connection to toggle reset pin.

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -1949,7 +1949,7 @@ class JLink(object):
         """
         return self._dll.JLINKARM_SetResetType(strategy)
 
-    @connection_required
+    @open_required
     def set_reset_pin_high(self):
         """Sets the reset pin high.
 
@@ -1962,7 +1962,7 @@ class JLink(object):
         self._dll.JLINKARM_SetRESET()
         return None
 
-    @connection_required
+    @open_required
     def set_reset_pin_low(self):
         """Sets the reset pin low.
 


### PR DESCRIPTION
Hello,
 I just tested some situation with modified PyOCD support for Pylink and found out that is not possible to toggle with reset pin without target connection established. So I change this to check that only the debug probe must be connected.

Thanks for implementation and publish :-)
Petr