### PR TITLE
Add raw JTAG support

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -5191,3 +5191,40 @@ class JLink(object):
         if res != 0:
             raise errors.JLinkException(res)
         return res
+        
+###############################################################################
+#
+# JTAG API (Raw JTAG access for boundary scan or other purposes)
+#
+###############################################################################
+
+    @interface_required(enums.JLinkInterfaces.JTAG)
+    def jtag_rawrw(self, tdo, tms, numbits=None):
+        """Writes a list of raw bits to TDO+TMS, returns TDI input.
+
+        Args:
+          self (JLink): the ``JLink`` instance
+          tdo (List): List of bytes to be shifted out tdo.
+          tms (List): list of bytes to be shifted out tms.
+          numbits (Int): Number of bits to shift out in total.
+
+        Returns:
+          tdi (List): Output from device shifted into tdi.
+        """
+        
+        if len(tdo) != len(tms):
+            raise ValueError("TMS & TDO arrays must be same length")
+        
+        buf_size = len(tdo)
+        
+        if numbits is None:
+            numbits = len(tdo)*8
+        
+        tdobuf = (ctypes.c_ubyte * buf_size)(*bytearray(tdo))
+        tmsbuf = (ctypes.c_ubyte * buf_size)(*bytearray(tms))
+        tdibuf = (ctypes.c_ubyte * buf_size)()
+
+        self._dll.JLINKARM_JTAG_StoreGetRaw(tdobuf, tdibuf, tmsbuf, numbits)
+        
+        return list(tdibuf)
+


### PR DESCRIPTION
This adds a single feature from the 'raw jtag' API allowing TMS/TDI/TDO control. This is useful to implement boundary scan mode (which I'm working on in another library called pyjtagbs). Other raw commands could be added, but are harder to use in practice as they require more information about the scan chain sent to the J-Link, most software seems to use this API only.

You should be able to use the code like this:

```
import pylink
jl = pylink.JLink() #Defaults to JTAG (not SWD)
jl.open() #Open but *do not* connect
jl.jtag_rawrw([0], [0x1F], 5) #JTAG Reset (tms = 1 for 5 bits)
jl.jtag_rawrw([0], [0x02], 4) #JTAG ID read
result = jl.jtag_rawrw([0]*8, [0]*8) #Shift to see what's on scan chain
print(result)
hex_id = hex(struct.unpack("<I", bytes(result[0:4]))[0])
print(hex_id)
```
If a single item - will just see 4 bytes. You can print the `hex_id` to see the standard format - testing on a Spartan 6 LX9 shows me `0x3622093` which matches the expected device id.

Note there is no .connect() - you can't connect to the chain as that will start trying to discover devices on it (which may be unsupported devices).