### PR TITLE
argparse: Handle python3 with no CLI arguments

### DIFF
--- a/pylink/__main__.py
+++ b/pylink/__main__.py
@@ -596,7 +596,14 @@ def main(args=None):
     logging.basicConfig(level=level)
 
     try:
-        args.command(args)
+        if hasattr(args, 'command'):
+            args.command(args)
+        else:
+            # Python 3 argparse won't create the command attribute and an
+            # AttributeError will be raised if no commands are specified. Note:
+            # Python 3.7 added support for subparsers being required.  Emulate
+            # Python 2 error here for consistent behavior.
+            parser.error('too few arguments')
     except pylink.JLinkException as e:
         sys.stderr.write('Error: %s%s' % (str(e), os.linesep))
         return 1


### PR DESCRIPTION
* Python 3 argparse won't create the command attribute and an
  AttributeError will be raised if no commands are specified.
* Tested on Python 2.7, 3.5, 3.6, 3.7, 3.8, 3.9.
* Without this fix, the following error was generated:
```
    File "pylink/__main__.py", line 599, in main
      args.command(args)
    AttributeError: 'Namespace' object has no attribute 'command'
```

Tests:
```
$ for i in 2.7 3.5 3.6 3.7 3.8 3.9; do 
    docker run -v $PWD:/w:ro --workdir /w -e HOME=/tmp --rm -u $(id -u):$(id -g) -it python:$i sh -c 'python --version ; pip install -q --no-warn-script-location  --user -r requirements.txt && python -m pylink'
    echo -e '\n=========================================\n';
done

Python 2.7.18
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: You are using pip version 20.0.2; however, version 20.3.4 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
usage: pylink [-h] [--version] [-v]
              {emulator,info,firmware,flash,unlock,erase,license} ...
pylink: error: too few arguments

=========================================

Python 3.5.10
DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.
WARNING: You are using pip version 20.2.3; however, version 20.3.4 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
usage: pylink [-h] [--version] [-v]
              {license,info,flash,firmware,emulator,erase,unlock} ...
pylink: error: too few arguments

=========================================

Python 3.6.15
usage: pylink [-h] [--version] [-v]
              {erase,flash,unlock,license,info,emulator,firmware} ...
pylink: error: too few arguments

=========================================

Python 3.7.12
usage: pylink [-h] [--version] [-v]
              {erase,flash,unlock,license,info,emulator,firmware} ...
pylink: error: too few arguments

=========================================

Python 3.8.12
usage: pylink [-h] [--version] [-v] {erase,flash,unlock,license,info,emulator,firmware} ...
pylink: error: too few arguments

=========================================

Python 3.9.7
usage: pylink [-h] [--version] [-v] {erase,flash,unlock,license,info,emulator,firmware} ...
pylink: error: too few arguments

=========================================
```

Closes #47 