### PR TITLE
Add JLink Resume Command

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -2315,6 +2315,28 @@ class JLink(object):
         return True
 
     @connection_required
+    def resume(self):
+        """Resumes execution on the CPU Core.
+
+        Args:
+          self (JLink): the ``JLink`` instance
+
+        Returns:
+          ``True`` if resumed, ``False`` otherwise.
+
+        Raises:
+          JLinkException: if the device is not halted.
+        """
+        if not self.halted():
+            raise errors.JLinkException("The device was not halted when calling resume.")
+
+        res = int(self._dll.JLINKARM_Go())
+        if res == 0:
+            return not self.halted()
+
+        return False
+
+    @connection_required
     @decorators.async_decorator
     def halt(self):
         """Halts the CPU Core.


### PR DESCRIPTION
This PR adds a `resume()` command to enable resuming JLink operation when a core is halted.

This functionality is needed, in addition to being able to programmatically halt and resume operation on the core, because I found that some MCUs are automatically halted by JLink after a call to `jlink.connect()`. The only way I could find to get the CPU to continue (without resetting) was to add a call to `JLINKARM_Go` after the connection completed.