### PR TITLE
[ISSUE-113] Connection Happens Twice when `connect()` is called.

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -1128,9 +1128,13 @@ class JLink(object):
         else:
             self.set_speed(speed)
 
-        result = self._dll.JLINKARM_Connect()
-        if result < 0:
-            raise errors.JLinkException(result)
+        # When we specify 'Device =', we will trigger an auto-connect to the
+        # target under debugging. If the 'exec_command' failed, then we want
+        # to force the connect here.
+        if not self.target_connected():
+            result = self._dll.JLINKARM_Connect()
+            if result < 0:
+                raise errors.JLinkException(result)
 
         try:
             # Issue a no-op command after connect. This has to be in a try-catch.

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -1288,6 +1288,9 @@ class TestJLink(unittest.TestCase):
           ``None``
         """
         self.dll.JLINKARM_ExecCommand.return_value = 0
+        self.dll.JLINKARM_IsOpen.return_value = 1
+        self.dll.JLINKARM_EMU_IsConnected.return_value = 1
+        self.dll.JLINKARM_IsConnected.return_value = 0
         self.dll.JLINKARM_Connect.return_value = -1
         self.dll.JLINKARM_IsHalted.return_value = 0
         self.dll.JLINKARM_DEVICE_GetIndex.return_value = 1
@@ -1316,6 +1319,9 @@ class TestJLink(unittest.TestCase):
           ``None``
         """
         self.dll.JLINKARM_ExecCommand.return_value = 0
+        self.dll.JLINKARM_IsOpen.return_value = 1
+        self.dll.JLINKARM_EMU_IsConnected.return_value = 1
+        self.dll.JLINKARM_IsConnected.return_value = 1
         self.dll.JLINKARM_Connect.return_value = 0
         self.dll.JLINKARM_IsHalted.return_value = 0
         self.dll.JLINKARM_DEVICE_GetIndex.return_value = 1
@@ -1327,7 +1333,7 @@ class TestJLink(unittest.TestCase):
         self.assertEqual(None, self.jlink.connect('device', speed='auto'))
 
         self.assertEqual(1, self.dll.JLINKARM_ExecCommand.call_count)
-        self.assertEqual(1, self.dll.JLINKARM_Connect.call_count)
+        self.assertEqual(0, self.dll.JLINKARM_Connect.call_count)
         self.assertEqual(1, self.dll.JLINKARM_IsHalted.call_count)
         self.assertEqual(1, self.dll.JLINKARM_DEVICE_GetIndex.call_count)
 
@@ -1343,6 +1349,9 @@ class TestJLink(unittest.TestCase):
           ``None``
         """
         self.dll.JLINKARM_ExecCommand.return_value = 0
+        self.dll.JLINKARM_IsOpen.return_value = 1
+        self.dll.JLINKARM_EMU_IsConnected.return_value = 1
+        self.dll.JLINKARM_IsConnected.side_effect = [0, 1]
         self.dll.JLINKARM_Connect.return_value = 0
         self.dll.JLINKARM_IsHalted.return_value = 0
         self.dll.JLINKARM_DEVICE_GetIndex.return_value = 1
@@ -1370,6 +1379,9 @@ class TestJLink(unittest.TestCase):
           ``None``
         """
         self.dll.JLINKARM_ExecCommand.return_value = 0
+        self.dll.JLINKARM_IsOpen.return_value = 1
+        self.dll.JLINKARM_EMU_IsConnected.return_value = 1
+        self.dll.JLINKARM_IsConnected.return_value = 0
         self.dll.JLINKARM_Connect.return_value = 0
         self.dll.JLINKARM_IsHalted.return_value = 0
         self.dll.JLINKARM_DEVICE_GetIndex.return_value = 1
@@ -1398,6 +1410,9 @@ class TestJLink(unittest.TestCase):
           ``None``
         """
         self.dll.JLINKARM_ExecCommand.return_value = 0
+        self.dll.JLINKARM_IsOpen.return_value = 1
+        self.dll.JLINKARM_EMU_IsConnected.return_value = 1
+        self.dll.JLINKARM_IsConnected.side_effect = [0, 1]
         self.dll.JLINKARM_Connect.return_value = 0
         self.dll.JLINKARM_IsHalted.return_value = 0
         self.dll.JLINKARM_DEVICE_GetIndex.return_value = 1
@@ -1425,6 +1440,9 @@ class TestJLink(unittest.TestCase):
           ``None``
         """
         self.dll.JLINKARM_ExecCommand.return_value = 0
+        self.dll.JLINKARM_IsOpen.return_value = 1
+        self.dll.JLINKARM_EMU_IsConnected.return_value = 1
+        self.dll.JLINKARM_IsConnected.side_effect = [0, 1]
         self.dll.JLINKARM_Connect.return_value = 0
         self.dll.JLINKARM_IsHalted.return_value = 0
         self.dll.JLINKARM_DEVICE_GetIndex.return_value = 1
@@ -1452,6 +1470,9 @@ class TestJLink(unittest.TestCase):
           ``None``
         """
         self.dll.JLINKARM_ExecCommand.return_value = 0
+        self.dll.JLINKARM_IsOpen.return_value = 1
+        self.dll.JLINKARM_EMU_IsConnected.return_value = 1
+        self.dll.JLINKARM_IsConnected.return_value = 0
         self.dll.JLINKARM_Connect.return_value = 0
         self.dll.JLINKARM_IsHalted.return_value = 0
         self.dll.JLINKARM_DEVICE_GetIndex.return_value = -1


### PR DESCRIPTION
## ISSUE-113: Connection Happens Twice when `connect()` is called.
### Description
This PR addresses an issue where target connection occurs twice when `connect()` is called. With some targets and versions, it appears like the `EXEC` command with `Device = ` results in an auto-connect occurring.