### PR TITLE
Library: patch possible misuse of find_library()

### DIFF
--- a/pylink/library.py
+++ b/pylink/library.py
@@ -475,7 +475,7 @@ class JLinkDllInfo:
             ('l_prev', ctypes.c_void_p),
         ]
 
-    def __init__(self, jlink_libname: str):
+    def __init__(self, jlink_libname):
         self._dll_path = None
 
         jlink_libfound = ctypes_util.find_library(jlink_libname)
@@ -519,7 +519,7 @@ class JLinkDllInfo:
         tmp_cdll_jlink = None
 
     @property
-    def path(self) -> str | None:
+    def path(self):
         """Answers the JLink library full path, or None if we failed to resolve
         the library by name.
         """

--- a/pylink/library.py
+++ b/pylink/library.py
@@ -82,10 +82,20 @@ class Library(object):
         'JLINK_SetFlashProgProgressCallback'
     ]
 
-    JLINK_SDK_NAME = 'libjlinkarm'
+    # Linux/MacOS: The JLink library name without any prefix like lib,
+    # suffix like .so, .dylib or version number.
+    JLINK_SDK_NAME = 'jlinkarm'
 
     WINDOWS_32_JLINK_SDK_NAME = 'JLinkARM'
     WINDOWS_64_JLINK_SDK_NAME = 'JLink_x64'
+
+    # Poor man's singleton: having this as a class member avoids to create
+    # a new JLinkDllInfo() for each pylink.Library instance.
+    #
+    # For e.g., the simple 'pyocd list' command creates three instances
+    # of the pylink.Library class, and it's worth not repeating the dlinfo()
+    # dance three times.
+    _dllinfo = None
 
     @classmethod
     def get_appropriate_windows_sdk_name(cls):
@@ -283,7 +293,13 @@ class Library(object):
         Returns:
           ``True`` if the DLL was loaded, otherwise ``False``.
         """
-        path = ctypes_util.find_library(self._sdk)
+
+        # Try to resolve the library by name, within the standard system search
+        # path, including LD_LIBRARY_PATH and suchlike.
+        if Library._dllinfo is None:
+            Library._dllinfo = JLinkDllInfo(self._sdk)
+        path = Library._dllinfo.path
+
         if path is None:
             # Couldn't find it the standard way.  Fallback to the non-standard
             # way of finding the J-Link library.  These methods are operating
@@ -423,3 +439,88 @@ class Library(object):
           A ``ctypes`` DLL instance if one was loaded, otherwise ``None``.
         """
         return self._lib
+
+
+class JLinkDllInfo:
+    """Helper used to find the absolute path of the JLink library (aka DLL).
+
+    The idea here is to rely on the underlying operating system, through ctypes,
+    for resolving the library file within its standard search path,
+    including LD_LIBRARY_PATH on Linux and DYLD_LIBRARY_PATH on MacOS:
+    - On Windows and MacOS, find_library() should already return the
+      full file path, so we'll just use that
+    - On Linux, find_library() should return the so name,
+      for e.g. libjlinkarm.so.7, and we'll have to additionaly use the native
+      dlinfo() API to retrieve the full file path
+
+    For e.g.:
+    - LD_LIBRARY_PATH=/mnt/platform/segger/JLink
+    - JLinkarmDllInfo('jlinkarm').path -> /mnt/platform/segger/JLink/libjlinkarm.so.7
+
+    The dlinfo() dance implementation is adapted from @cloudflightio,
+    https://github.com/cloudflightio/python-dlinfo.
+    """
+
+    # dlinfo(3)
+    # request: Obtain a pointer to the link_map structure corresponding to handle.
+    RTLD_DI_LINKMAP = 2
+
+    # dlinfo(3): struct link_map, where ld_name will be the file path.
+    class LinkMap(ctypes.Structure):
+        _fields_ = [
+            ('l_addr', ctypes.c_void_p),
+            ('l_name', ctypes.c_char_p),
+            ('l_ld', ctypes.c_void_p),
+            ('l_next', ctypes.c_void_p),
+            ('l_prev', ctypes.c_void_p),
+        ]
+
+    def __init__(self, jlink_libname: str):
+        self._dll_path = None
+
+        jlink_libfound = ctypes_util.find_library(jlink_libname)
+
+        if jlink_libfound is None:
+            # On all platforms, find_library() returns None when the dynamic
+            # linker has failed to resolve the given library name.
+            return
+
+        if not sys.platform.startswith("linux"):
+            # On MacOS and Windows, find_library() already returns the full path.
+            self._dll_path = jlink_libfound
+            return
+
+        # On Linux, find_library() returns a soname, for e.g. libjlinkarm.so.7,
+        # that LoadLibrary() should load just fine.
+        tmp_cdll_jlink = ctypes.cdll.LoadLibrary(jlink_libfound)
+
+        # dlinfo() dance to retrieve the full library filepath.
+        #
+        dl_soname = ctypes_util.find_library('dl')
+        if dl_soname is None:
+            # Should not happen
+            return
+        tmp_cdll_dl = ctypes.cdll.LoadLibrary(dl_soname)
+        tmp_dlinfo = tmp_cdll_dl.dlinfo
+        tmp_dlinfo.argtypes = ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p
+        tmp_dlinfo.restype = ctypes.c_int
+
+        tmp_linkmap = ctypes.c_void_p()
+        if tmp_dlinfo(tmp_cdll_jlink._handle, self.RTLD_DI_LINKMAP, ctypes.byref(tmp_linkmap)) == 0:
+            tmp_linkmap = ctypes.cast(tmp_linkmap, ctypes.POINTER(JLinkDllInfo.LinkMap))
+            self._dll_path = tmp_linkmap.contents.l_name.decode(sys.getdefaultencoding())
+
+        # According to comments in the Library.unload() function,
+        # on Linux we should NOT call FreeLibrary(),
+        # but just free the Python references for /immediate/ GC.
+        del tmp_cdll_dl
+        tmp_cdll_dl = None
+        del tmp_cdll_jlink
+        tmp_cdll_jlink = None
+
+    @property
+    def path(self) -> str | None:
+        """Answers the JLink library full path, or None if we failed to resolve
+        the library by name.
+        """
+        return self._dll_path

--- a/pylink/library.py
+++ b/pylink/library.py
@@ -86,6 +86,12 @@ class Library(object):
     # suffix like .so, .dylib or version number.
     JLINK_SDK_NAME = 'jlinkarm'
 
+    # Linux/MacOS: The library file name will start with 'libjlinkarm'
+    # Used by Library.find_library_{linux,darwin}()
+    JLINK_SDK_STARTS_WITH = 'libjlinkarm'
+
+    # Windows: these are suitable for both the ctypes find_library() API,
+    # and for the directory scanning done in Library.find_library_windows()
     WINDOWS_32_JLINK_SDK_NAME = 'JLinkARM'
     WINDOWS_64_JLINK_SDK_NAME = 'JLink_x64'
 
@@ -167,7 +173,7 @@ class Library(object):
           The paths to the J-Link library files in the order that they are
           found.
         """
-        dll = Library.JLINK_SDK_NAME
+        dll = Library.JLINK_SDK_STARTS_WITH
         root = os.path.join('/', 'opt', 'SEGGER')
 
         for (directory_name, subdirs, files) in os.walk(root):
@@ -216,7 +222,7 @@ class Library(object):
         Returns:
           The path to the J-Link library files in the order they are found.
         """
-        dll = Library.JLINK_SDK_NAME
+        dll = Library.JLINK_SDK_STARTS_WITH
         root = os.path.join('/', 'Applications', 'SEGGER')
         if not os.path.isdir(root):
             return

--- a/pylink/library.py
+++ b/pylink/library.py
@@ -307,7 +307,7 @@ class Library(object):
         # library name.
         path = ctypes_util.find_library(self._sdk)
 
-        if path is not None and sys.platform.startswith("linux"):
+        if (path is not None) and sys.platform.startswith('linux'):
             # On Linux, find_library() actually returns the soname,
             # so we've got something like path = 'libjlinkarm.so.7',
             # and we have to retrieve the absolute file path.

--- a/tests/unit/test_library.py
+++ b/tests/unit/test_library.py
@@ -957,7 +957,7 @@ class TestLibrary(unittest.TestCase):
     @mock.patch('pylink.library.open')
     @mock.patch('pylink.library.os')
     @mock.patch('pylink.util.is_os_64bit', return_value=True)
-    @mock.patch('pylink.platform.libc_ver', return_value = ('libc', '1.0'))
+    @mock.patch('pylink.platform.libc_ver', return_value=('libc', '1.0'))
     @mock.patch('ctypes.util.find_library', return_value='libjlinkarm.so.7')
     @mock.patch('pylink.library.JLinkarmDlInfo.__init__')
     @mock.patch('ctypes.cdll.LoadLibrary')
@@ -997,7 +997,7 @@ class TestLibrary(unittest.TestCase):
     @mock.patch('pylink.library.open')
     @mock.patch('pylink.library.os')
     @mock.patch('pylink.util.is_os_64bit', return_value=True)
-    @mock.patch('pylink.platform.libc_ver', return_value = ('glibc', '2.34'))
+    @mock.patch('pylink.platform.libc_ver', return_value=('glibc', '2.34'))
     @mock.patch('ctypes.util.find_library')
     @mock.patch('ctypes.cdll.LoadLibrary')
     def test_linux_dl_unavailable(self, mock_load_library, mock_find_library, mock_libc_ver,
@@ -1039,7 +1039,7 @@ class TestLibrary(unittest.TestCase):
 
     @mock.patch('os.name', new='posix')
     @mock.patch('sys.platform', new='linux')
-    @mock.patch('pylink.platform.libc_ver', return_value = ('glibc', '2.34'))
+    @mock.patch('pylink.platform.libc_ver', return_value=('glibc', '2.34'))
     @mock.patch('ctypes.util.find_library')
     @mock.patch('ctypes.cdll.LoadLibrary')
     def test_linux_dl_oserror(self, mock_load_library, mock_find_library, mock_libc_ver):
@@ -1072,6 +1072,7 @@ class TestLibrary(unittest.TestCase):
         mock_find_library.assert_any_call('dl')
         self.assertEquals(2, mock_find_library.call_count)
         self.assertEquals(2, mock_load_library.call_count)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
On Linux, the Library.load_default() function fails
to properly resolve the JLink shared library if not
installed in /opt/SEGGER/JLink, regardless of the
value of LD_LIBRARY_PATH.

This is possibly caused by an improper use of the
ctypes find_library() API, which:
- on all platforms expects as parameter the library
  name without any prefix like lib, suffix like .so,
  .dylib or version number
- returns the full file path on MacOS and Windows,
  but only the file name (so name) on Linux

Thus:
- On Windows: find_library('JLinkARM') or
  find_library('JLink_x64') should indeed succeed,
  and actually return the expected full file path
- On MacOS: although find_library() would also return
  the full file path, calling find_library('libjlinkarm')
  will fail
- On Linux, find_library('libjlinkarm') will also fail,
  and would not have returned the full file path anyway

Changes introduced by this patch:
- On Windows find_library(self._sdk) already succeeds,
  and returns the full file path: this patch does not
  introduce any change here
- On MacOS, find_library() will use 'jlinkarm' (and not
  'libjlinkarm') as parameter, which should succeed,
  and return the full file path
- On Linux find_library('jlinkarm') will return the
  resolved soname, for e.g. 'libjlinkarm.so.7',
  and we'll use the native dlinfo() API to retrieve
  the full file path

If I'm correct, this should not break anything on Windows,
and improve things on both Linux and MacOS.