### PR TITLE
Revert JLINK_SDK_NAME value to 'libjlinkarm'

### DIFF
--- a/pylink/library.py
+++ b/pylink/library.py
@@ -83,13 +83,22 @@ class Library(object):
         'JLINK_SetFlashProgProgressCallback'
     ]
 
-    # Linux/MacOS: The JLink library name without any prefix like lib,
-    # suffix like .so, .dylib or version number.
-    JLINK_SDK_NAME = 'jlinkarm'
+    JLINK_SDK_NAME = 'libjlinkarm'
+    """On Linux and macOS, represents the library file name prefix
+    (the part just before .so or .dylib).
 
-    # Linux/MacOS: The library file name will start with 'libjlinkarm'
-    # Used by Library.find_library_{linux,darwin}()
-    JLINK_SDK_STARTS_WITH = 'libjlinkarm'
+    This is the value appropriate when calling the find_library_{linux,darwin}()
+    functions bellow.
+
+    Note: this "constant" is also used by downstream projects,
+    and should therefore be considered public (frozen) API.
+    """
+
+    # Linux/MacOS: The JLink shared object name, without any prefix like lib,
+    # suffix like .so, .dylib or version number.
+    #
+    # This is the value appropriate when invoking the ctypes API find_libary().
+    JLINK_SDK_OBJECT = 'jlinkarm'
 
     # Windows: these are suitable for both the ctypes find_library() API,
     # and for the directory scanning done in Library.find_library_windows()
@@ -176,7 +185,7 @@ class Library(object):
           The paths to the J-Link library files in the order that they are
           found.
         """
-        dll = Library.JLINK_SDK_STARTS_WITH
+        dll = Library.JLINK_SDK_NAME
         root = os.path.join('/', 'opt', 'SEGGER')
 
         for (directory_name, subdirs, files) in os.walk(root):
@@ -225,7 +234,7 @@ class Library(object):
         Returns:
           The path to the J-Link library files in the order they are found.
         """
-        dll = Library.JLINK_SDK_STARTS_WITH
+        dll = Library.JLINK_SDK_NAME
         root = os.path.join('/', 'Applications', 'SEGGER')
         if not os.path.isdir(root):
             return
@@ -272,7 +281,7 @@ class Library(object):
         if self._windows or self._cygwin:
             self._sdk = self.get_appropriate_windows_sdk_name()
         else:
-            self._sdk = self.JLINK_SDK_NAME
+            self._sdk = self.JLINK_SDK_OBJECT
 
         if dllpath is not None:
             self.load(dllpath)

--- a/pylink/library.py
+++ b/pylink/library.py
@@ -83,16 +83,15 @@ class Library(object):
         'JLINK_SetFlashProgProgressCallback'
     ]
 
+    # On Linux and macOS, represents the library file name prefix
+    # (the part just before .so or .dylib).
+    #
+    # This is the value appropriate when calling the find_library_{linux,darwin}()
+    # functions below.
+    #
+    # Note: this "constant" is also used by downstream projects,
+    # and should therefore be considered public (frozen) API.
     JLINK_SDK_NAME = 'libjlinkarm'
-    """On Linux and macOS, represents the library file name prefix
-    (the part just before .so or .dylib).
-
-    This is the value appropriate when calling the find_library_{linux,darwin}()
-    functions bellow.
-
-    Note: this "constant" is also used by downstream projects,
-    and should therefore be considered public (frozen) API.
-    """
 
     # Linux/MacOS: The JLink shared object name, without any prefix like lib,
     # suffix like .so, .dylib or version number.

--- a/tests/unit/test_library.py
+++ b/tests/unit/test_library.py
@@ -151,7 +151,7 @@ class TestLibrary(unittest.TestCase):
         lib = library.Library()
         lib.unload = mock.Mock()
 
-        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_NAME)
+        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_OBJECT)
         mock_open.assert_called_with(self.lib_path, 'rb')
         mock_load_library.assert_called_once()
 
@@ -182,7 +182,7 @@ class TestLibrary(unittest.TestCase):
         lib = library.Library()
         lib.unload = mock.Mock()
 
-        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_NAME)
+        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_OBJECT)
         self.assertEqual(1, mock_find_library.call_count)
         self.assertEqual(0, mock_load_library.call_count)
 
@@ -317,7 +317,7 @@ class TestLibrary(unittest.TestCase):
         lib = library.Library()
         lib.unload = mock.Mock()
 
-        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_NAME)
+        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_OBJECT)
         self.assertEqual(1, mock_find_library.call_count)
 
         mock_open.assert_called_with(self.lib_path, 'rb')
@@ -431,7 +431,7 @@ class TestLibrary(unittest.TestCase):
         lib = library.Library()
         lib.unload = mock.Mock()
 
-        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_NAME)
+        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_OBJECT)
         self.assertEqual(1, mock_find_library.call_count)
 
         mock_open.assert_called_with(self.lib_path, 'rb')
@@ -469,7 +469,7 @@ class TestLibrary(unittest.TestCase):
         lib = library.Library()
         lib.unload = mock.Mock()
 
-        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_NAME)
+        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_OBJECT)
         self.assertEqual(1, mock_find_library.call_count)
         self.assertEqual(1, mock_load_library.call_count)
 
@@ -504,7 +504,7 @@ class TestLibrary(unittest.TestCase):
         lib = library.Library()
         lib.unload = mock.Mock()
 
-        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_NAME)
+        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_OBJECT)
         self.assertEqual(1, mock_find_library.call_count)
         self.assertEqual(1, mock_load_library.call_count)
 
@@ -538,7 +538,7 @@ class TestLibrary(unittest.TestCase):
         lib = library.Library()
         lib.unload = mock.Mock()
 
-        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_NAME)
+        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_OBJECT)
         self.assertEqual(1, mock_find_library.call_count)
         self.assertEqual(1, mock_load_library.call_count)
 
@@ -572,7 +572,7 @@ class TestLibrary(unittest.TestCase):
         lib = library.Library()
         lib.unload = mock.Mock()
 
-        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_NAME)
+        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_OBJECT)
         self.assertEqual(1, mock_find_library.call_count)
         self.assertEqual(0, mock_load_library.call_count)
 
@@ -946,7 +946,7 @@ class TestLibrary(unittest.TestCase):
         lib = library.Library()
         lib.unload = mock.Mock()
 
-        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_NAME)
+        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_OBJECT)
         self.assertEqual(1, mock_find_library.call_count)
         self.assertEqual(0, mock_load_library.call_count)
 
@@ -983,7 +983,7 @@ class TestLibrary(unittest.TestCase):
         lib = library.Library()
         lib.unload = mock.Mock()
 
-        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_NAME)
+        mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_OBJECT)
         # JLinkarmDlInfo has not been instantiated.
         self.assertEquals(0, mock_dlinfo_ctr.call_count)
         # Fallback to "search by file name" has succeeded.
@@ -1027,7 +1027,7 @@ class TestLibrary(unittest.TestCase):
         lib = library.Library()
         lib.unload = mock.Mock()
 
-        mock_find_library.assert_any_call(library.Library.JLINK_SDK_NAME)
+        mock_find_library.assert_any_call(library.Library.JLINK_SDK_OBJECT)
         mock_find_library.assert_any_call('dl')
         self.assertEquals(2, mock_find_library.call_count)
         # Called once in JLinkarmDlInfo and once in Library.
@@ -1068,7 +1068,7 @@ class TestLibrary(unittest.TestCase):
             lib = library.Library()
             lib.unload = mock.Mock()
 
-        mock_find_library.assert_any_call(library.Library.JLINK_SDK_NAME)
+        mock_find_library.assert_any_call(library.Library.JLINK_SDK_OBJECT)
         mock_find_library.assert_any_call('dl')
         self.assertEquals(2, mock_find_library.call_count)
         self.assertEquals(2, mock_load_library.call_count)


### PR DESCRIPTION
On Linux and macOS, the single constant JLINK_SDK_NAME has
been used internally by the pylink Library class as both:
- the library name parameter for the ctypes API find_library()
- the library file name prefix when searching the
  filesystem for the JLink DLL in find_library_{linux,darwin}()

To fix the call to find_library(JLINK_SDK_NAME),
the PR #132:
- sets JLINK_SDK_NAME to 'jlinkarm'
- moves the file name prefix semantic to the constant
  JLINK_SDK_STARTS_WITH, with value 'libjlinkarm'

Unfortunately, there is at least one (sensible) downstream
project which implementation assumes Library.JLINK_SDK_NAME
is the (public) API for the file name prefix semantic.

This patch moves the file name prefix semantic back to the
JLINK_SDK_NAME constant, drops JLINK_SDK_STARTS_WITH,
and moves the library name semantic to JLINK_SDK_OBJECT.

Unit tests are patched accordingly.