### PR TITLE
Fix an E275 error in functional tests

### DIFF
--- a/tests/functional/features/steps/common.py
+++ b/tests/functional/features/steps/common.py
@@ -333,7 +333,7 @@ def step_process_jlink_connected(context):
     process.start()
     process.join()
 
-    assert(all(queue.get() for _ in range(2)))
+    assert all(queue.get() for _ in range(2))
 
 
 @behave.then('I should not be able to open a new connection to it')


### PR DESCRIPTION
Should fix #140.

Considering the git history of `tests/functional/features/steps/common.py`, I don't understand why this error is just occuring *now*, though.