### PR TITLE
Remove mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -263,11 +263,6 @@ setuptools.setup(
     # Tests
     test_suite='tests',
 
-    # Test requirements
-    tests_require=[
-        'mock == 2.0.0'
-    ],
-
     # Additional scripts.
     scripts=[
         os.path.join('examples', 'pylink-rtt'),

--- a/tests/unit/protocols/test_swd.py
+++ b/tests/unit/protocols/test_swd.py
@@ -15,7 +15,7 @@
 import pylink.protocols.swd as swd
 import pylink.util
 
-import mock
+from unittest import mock
 
 import unittest
 

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -14,7 +14,7 @@
 
 import pylink.decorators as decorators
 
-import mock
+from unittest import mock
 
 import threading
 import unittest

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -20,7 +20,7 @@ import pylink.structs as structs
 import pylink.unlockers.unlock_kinetis as unlock_kinetis
 import pylink.util as util
 
-import mock
+from unittest import mock
 
 try:
     import StringIO

--- a/tests/unit/test_jlock.py
+++ b/tests/unit/test_jlock.py
@@ -14,7 +14,7 @@
 
 import pylink.jlock as jlock
 
-import mock
+from unittest import mock
 
 import errno
 import os

--- a/tests/unit/test_library.py
+++ b/tests/unit/test_library.py
@@ -16,7 +16,7 @@ from platform import platform
 import pylink.library as library
 import pylink.util as util
 
-import mock
+from unittest import mock
 
 import unittest
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -16,7 +16,7 @@ import pylink
 import pylink.__main__ as main
 
 import logging
-import mock
+from unittest import mock
 
 try:
     import StringIO

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -15,7 +15,7 @@
 import pylink.enums as enums
 import pylink.util as util
 
-import mock
+from unittest import mock
 
 try:
     import StringIO

--- a/tests/unit/unlockers/test_unlock.py
+++ b/tests/unit/unlockers/test_unlock.py
@@ -14,7 +14,7 @@
 
 import pylink.unlockers as unlock
 
-import mock
+from unittest import mock
 
 import unittest
 

--- a/tests/unit/unlockers/test_unlock_kinetis.py
+++ b/tests/unit/unlockers/test_unlock_kinetis.py
@@ -16,7 +16,7 @@ import pylink.enums as enums
 import pylink.protocols.swd as swd
 import pylink.unlockers as unlock
 
-import mock
+from unittest import mock
 
 import unittest
 


### PR DESCRIPTION
Replace the use of mock with unittest.mock and drop the test requirement on mock.

Fixes #149 