### PR TITLE
Switch to read-modify-write flashing.

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -2195,7 +2195,7 @@ class JLink(object):
         # Perform read-modify-write operation.
         res = self._dll.JLINKARM_BeginDownload(flags=flags)
         if res < 0:
-          raise errors.JLinkEraseException(res)
+            raise errors.JLinkEraseException(res)
 
         bytes_flashed = self._dll.JLINKARM_WriteMem(addr, len(data), data)
 

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -2157,7 +2157,7 @@ class JLink(object):
 
         Args:
           self (JLink): the ``JLink`` instance
-          data (list): list of bytes to write to flash
+          data (list|bytes): list or byte object of bytes to write to flash
           addr (int): start address on flash which to write the data
           on_progress (function): callback to be triggered on flash progress
           power_on (boolean): whether to power the target before flashing
@@ -2196,6 +2196,9 @@ class JLink(object):
         res = self._dll.JLINKARM_BeginDownload(flags=flags)
         if res < 0:
             raise errors.JLinkEraseException(res)
+
+        if isinstance(data, list):
+            data = bytes(data)
 
         bytes_flashed = self._dll.JLINKARM_WriteMem(addr, len(data), data)
 

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -2192,9 +2192,18 @@ class JLink(object):
         except errors.JLinkException:
             pass
 
-        res = self.flash_write(addr, data, flags=flags)
+        # Perform read-modify-write operation.
+        res = self._dll.JLINKARM_BeginDownload(flags=flags)
+        if res < 0:
+          raise errors.JLinkEraseException(res)
 
-        return res
+        bytes_flashed = self._dll.JLINKARM_WriteMem(addr, len(data), data)
+
+        res = self._dll.JLINKARM_EndDownload()
+        if res < 0:
+            raise errors.JLinkEraseException(res)
+
+        return bytes_flashed
 
     @connection_required
     def flash_file(self, path, addr, on_progress=None, power_on=False):

--- a/pylink/library.py
+++ b/pylink/library.py
@@ -80,7 +80,10 @@ class Library(object):
         'JLINK_SWD_StoreRaw',
         'JLINK_SWD_SyncBits',
         'JLINK_SWD_SyncBytes',
-        'JLINK_SetFlashProgProgressCallback'
+        'JLINK_SetFlashProgProgressCallback',
+        'JLINKARM_BeginDownload',
+        'JLINKARM_EndDownload',
+        'JLINKARM_WriteMem'
     ]
 
     # On Linux and macOS, represents the library file name prefix

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -2715,7 +2715,7 @@ class TestJLink(unittest.TestCase):
         Returns:
           ``None``
         """
-        self.dll.JLINKARM_EndDownload.return_value = -1
+        self.dll.JLINKARM_WriteMem.return_value = 0
 
         self.jlink.power_on = mock.Mock()
         self.jlink.erase = mock.Mock()
@@ -2724,6 +2724,15 @@ class TestJLink(unittest.TestCase):
         self.jlink.halted = mock.Mock()
         self.jlink.halted.return_value = True
 
+        # BeginDownload failing
+        self.dll.JLINKARM_BeginDownload.return_value = -1
+        self.dll.JLINKARM_EndDownload.return_value = 0
+        with self.assertRaises(JLinkException):
+            self.jlink.flash([0], 0)
+
+        # EndDownload failing
+        self.dll.JLINKARM_BeginDownload.return_value = 0
+        self.dll.JLINKARM_EndDownload.return_value = -1
         with self.assertRaises(JLinkException):
             self.jlink.flash([0], 0)
 
@@ -2736,6 +2745,8 @@ class TestJLink(unittest.TestCase):
         Returns:
           ``None``
         """
+        self.dll.JLINKARM_BeginDownload.return_value = 0
+        self.dll.JLINKARM_WriteMem.return_value = 0
         self.dll.JLINKARM_EndDownload.return_value = 0
 
         self.jlink.power_on = mock.Mock()


### PR DESCRIPTION
This enables programming the chip without having to erase the entire contents. Instead, JLink will erase where needed while retaining the data that's within the same sectors but outside of the specified write area.

I was only able to run some of the Behave tests as I don't have access to the hardware.

Closes #154, #148