### PR TITLE
Fix RTT example never exit when CTRL-C (Windows).

### DIFF
--- a/examples/pylink-rtt
+++ b/examples/pylink-rtt
@@ -86,6 +86,8 @@ def write_rtt(jlink):
         while jlink.connected():
             bytes = list(bytearray(input(), "utf-8") + b"\x0A\x00")
             bytes_written = jlink.rtt_write(0, bytes)
+    except EOFError:
+        print("EOFError detected, exiting...")
     except Exception:
         print("IO write thread exception, exiting...")
         thread.interrupt_main()
@@ -148,8 +150,6 @@ def main(target_device, block_address=None):
         while jlink.connected():
             time.sleep(1)
         print("JLink disconnected, exiting...")
-    except EOFError:
-        print("EOFError detected, exiting...")
     except KeyboardInterrupt:
         print("ctrl-c detected, exiting...")
 

--- a/examples/pylink-rtt
+++ b/examples/pylink-rtt
@@ -148,10 +148,12 @@ def main(target_device, block_address=None):
         while jlink.connected():
             time.sleep(1)
         print("JLink disconnected, exiting...")
+    except EOFError:
+        print("EOFError detected, exiting...")
     except KeyboardInterrupt:
         print("ctrl-c detected, exiting...")
-        pass
 
+    jlink.close()
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Open RTT console.")
@@ -160,7 +162,7 @@ if __name__ == "__main__":
         help="Device Name (see https://www.segger.com/supported-devices/jlink/)")
     parser.add_argument(
         "rtt_block_address", help="RTT block address in hex",
-        type=lambda x: int(x, 16), nargs="?")
+        type=lambda x: int(x, 16), nargs="?", default=None)
 
     args = parser.parse_args()
 


### PR DESCRIPTION
The write thread raised `EOFError` when CTRL-C.
But the main thread not catched this and not closed jlink.
So the process never ended.