### PR TITLE
Update reset strategy to require open instead of connection

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -1961,7 +1961,7 @@ class JLink(object):
         """
         return self.set_trace_source(enums.JLinkTraceSource.ETM)
 
-    @connection_required
+    @open_required
     def set_reset_strategy(self, strategy):
         """Sets the reset strategy for the target.
 


### PR DESCRIPTION
I ran into an issue with an nRF52, where the micro allows the reset pin to be re-assigned, and use the soft reset (option 6) to reset the micro.  I could not establish a connection because the reset strategy was set to use the `nRESET` pin, and could not change the reset strategy in order to make a connection.