### PR TITLE
[Dependencies] Remove dependency on future

### DIFF
--- a/examples/pylink-rtt
+++ b/examples/pylink-rtt
@@ -28,7 +28,7 @@ import pylink
 import argparse
 import sys
 import time
-from builtins import input
+from six.moves import input
 
 try:
     import thread

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 behave == 1.2.5
 coverage == 4.4.1
-future
 psutil >= 5.2.2
 pycodestyle >= 2.3.1
 six

--- a/setup.py
+++ b/setup.py
@@ -261,7 +261,6 @@ setuptools.setup(
     # Dependencies.
     install_requires=[
         'psutil >= 5.2.2',
-        'future',
         'six'
     ],
 


### PR DESCRIPTION
Currently the python-future package is only used to provide `input`. However, `six` is also used within the source code for python2 compatibility. Replace the usage of `future` with `six` to trim the required dependencies.

python-future also does not provide built wheels, so removing it means that this package and all it's dependencies can be fetched as wheels without running any local build steps.