### PR TITLE
Introduce use_tmpcpy parameter to Library constructor.

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -247,7 +247,7 @@ class JLink(object):
         return _interface_required
 
     def __init__(self, lib=None, log=None, detailed_log=None, error=None, warn=None, unsecure_hook=None,
-                 serial_no=None, ip_addr=None, open_tunnel=False):
+                 serial_no=None, ip_addr=None, open_tunnel=False, use_tmpcpy=True):
         """Initializes the J-Link interface object.
 
         Note:
@@ -279,6 +279,7 @@ class JLink(object):
             of ``open`` method.
             If ``None``, the driver will not be opened automatically
             (however, it is still closed when exiting the context manager).
+          use_tmpcpy (bool): True to load a temporary copy of J-Link DLL
 
         Returns:
           ``None``
@@ -289,7 +290,7 @@ class JLink(object):
         self._initialized = False
 
         if lib is None:
-            lib = library.Library()
+            lib = library.Library(use_tmpcpy=use_tmpcpy)
 
         if lib.dll() is None:
             raise TypeError('Expected to be given a valid DLL.')


### PR DESCRIPTION
This parameter allow preventing temporary copy of J-Link Library.