### PR TITLE
JLINKARM_BeginDownload is void, not int.

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -2194,9 +2194,7 @@ class JLink(object):
             pass
 
         # Perform read-modify-write operation.
-        res = self._dll.JLINKARM_BeginDownload(flags=flags)
-        if res < 0:
-            raise errors.JLinkEraseException(res)
+        self._dll.JLINKARM_BeginDownload(flags=flags)
 
         if isinstance(data, list):
             data = bytes(data)

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -2724,14 +2724,7 @@ class TestJLink(unittest.TestCase):
         self.jlink.halted = mock.Mock()
         self.jlink.halted.return_value = True
 
-        # BeginDownload failing
-        self.dll.JLINKARM_BeginDownload.return_value = -1
-        self.dll.JLINKARM_EndDownload.return_value = 0
-        with self.assertRaises(JLinkException):
-            self.jlink.flash([0], 0)
-
         # EndDownload failing
-        self.dll.JLINKARM_BeginDownload.return_value = 0
         self.dll.JLINKARM_EndDownload.return_value = -1
         with self.assertRaises(JLinkException):
             self.jlink.flash([0], 0)
@@ -2745,7 +2738,6 @@ class TestJLink(unittest.TestCase):
         Returns:
           ``None``
         """
-        self.dll.JLINKARM_BeginDownload.return_value = 0
         self.dll.JLINKARM_WriteMem.return_value = 0
         self.dll.JLINKARM_EndDownload.return_value = 0
 


### PR DESCRIPTION
Reading a return value results in a nonsensical value and frequently an invalid exception.