### PR TITLE
Fix: Loading library on Aarch64 fails because pylink attempts to load 32-bit library

### DIFF
--- a/pylink/library.py
+++ b/pylink/library.py
@@ -218,7 +218,7 @@ class Library(object):
 
             for fname in fnames:
                 fpath = os.path.join(directory_name, fname)
-                if not self.can_load_library(fpath):
+                if not Library.can_load_library(fpath):
                     continue
                 if util.is_os_64bit():
                     if '_x86' not in fname:

--- a/pylink/library.py
+++ b/pylink/library.py
@@ -139,6 +139,22 @@ class Library(object):
             return Library.WINDOWS_32_JLINK_SDK_NAME
 
     @classmethod
+    def can_load_library(dllpath):
+        """Test whether a library is the correct architecture to load.
+
+        Args:
+          dllpath: A path to a library.
+
+        Returns:
+          True if the library could be successfully loaded, False if not.
+        """
+        try:
+            ctypes.CDLL(dllpath)
+            return True
+        except:
+            return False
+
+    @classmethod
     def find_library_windows(cls):
         """Loads the SEGGER DLL from the windows installation directory.
 
@@ -174,22 +190,6 @@ class Library(object):
                         yield lib_path
 
     @classmethod
-    def can_load_library(dllpath):
-        """Test whether a library is the correct architecture to load.
-
-        Args:
-          dllpath: A path to a library.
-
-        Returns:
-          True if the library could be successfully loaded, False if not.
-        """
-        try:
-            ctypes.CDLL(dllpath)
-            return True
-        except:
-            return False
-
-    @classmethod
     def find_library_linux(cls):
         """Loads the SEGGER DLL from the root directory.
 
@@ -218,7 +218,7 @@ class Library(object):
 
             for fname in fnames:
                 fpath = os.path.join(directory_name, fname)
-                if not Library.can_load_library(fpath):
+                if not cls.can_load_library(fpath):
                     continue
                 if util.is_os_64bit():
                     if '_x86' not in fname:

--- a/pylink/library.py
+++ b/pylink/library.py
@@ -139,7 +139,7 @@ class Library(object):
             return Library.WINDOWS_32_JLINK_SDK_NAME
 
     @classmethod
-    def can_load_library(dllpath):
+    def can_load_library(cls, dllpath):
         """Test whether a library is the correct architecture to load.
 
         Args:

--- a/pylink/library.py
+++ b/pylink/library.py
@@ -143,10 +143,11 @@ class Library(object):
         """Test whether a library is the correct architecture to load.
 
         Args:
-          dllpath: A path to a library.
+          cls (Library): the ``Library`` class
+          dllpath (str): A path to a library.
 
         Returns:
-          True if the library could be successfully loaded, False if not.
+          ``True`` if the library could be successfully loaded, ``False`` if not.
         """
         try:
             ctypes.CDLL(dllpath)

--- a/pylink/library.py
+++ b/pylink/library.py
@@ -174,6 +174,22 @@ class Library(object):
                         yield lib_path
 
     @classmethod
+    def can_load_library(dllpath):
+        """Test whether a library is the correct architecture to load.
+
+        Args:
+          dllpath: A path to a library.
+
+        Returns:
+          True if the library could be successfully loaded, False if not.
+        """
+        try:
+            ctypes.CDLL(dllpath)
+            return True
+        except:
+            return False
+
+    @classmethod
     def find_library_linux(cls):
         """Loads the SEGGER DLL from the root directory.
 
@@ -202,6 +218,8 @@ class Library(object):
 
             for fname in fnames:
                 fpath = os.path.join(directory_name, fname)
+                if not self.can_load_library(fpath):
+                    continue
                 if util.is_os_64bit():
                     if '_x86' not in fname:
                         yield fpath

--- a/pylink/library.py
+++ b/pylink/library.py
@@ -151,7 +151,7 @@ class Library(object):
         try:
             ctypes.CDLL(dllpath)
             return True
-        except:
+        except OSError:
             return False
 
     @classmethod
@@ -218,10 +218,10 @@ class Library(object):
 
             for fname in fnames:
                 fpath = os.path.join(directory_name, fname)
-                if not cls.can_load_library(fpath):
-                    continue
                 if util.is_os_64bit():
-                    if '_x86' not in fname:
+                    if not cls.can_load_library(fpath):
+                        continue
+                    elif '_x86' not in fname:
                         yield fpath
                 elif x86_found:
                     if '_x86' in fname:


### PR DESCRIPTION
The ARM64 version of the JLink software contains two library files, libjlinkarm.so (64 bit) and libjlinkarm_arm.so (32 bit). Pylink attempts to load libjlinkarm_arm.so first, which fails on ARM64 due to the architecture mismatch and causes an error. This change simply performs a 'test load' of each library file found, skipping if it fails, fixing this issue on ARM64.