### PR TITLE
Python 3.12 test updates

### DIFF
--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -2971,12 +2971,12 @@ class TestJLink(unittest.TestCase):
         self.jlink.halted.return_value = True
 
         self.assertEqual(True, self.jlink.restart())
-        self.dll.JLINKARM_GoEx.called_once_with(0, 0)
+        self.dll.JLINKARM_GoEx.assert_called_once_with(0, 0)
 
         self.dll.JLINKARM_GoEx = mock.Mock()
 
         self.assertEqual(True, self.jlink.restart(10, skip_breakpoints=True))
-        self.dll.JLINKARM_GoEx.called_once_with(10, enums.JLinkFlags.GO_OVERSTEP_BP)
+        self.dll.JLINKARM_GoEx.assert_called_once_with(10, enums.JLinkFlags.GO_OVERSTEP_BP)
 
     @mock.patch('time.sleep')
     def test_jlink_halt_failure(self, mock_sleep):
@@ -6218,7 +6218,7 @@ class TestJLink(unittest.TestCase):
 
         self.dll.JLINKARM_CP15_WriteEx.return_value = 0
         actual = self.jlink.cp15_register_write(*args)
-        assert self.dll.JLINKARM_CP15_WriteEx.called_once_with(*args)
+        assert self.dll.JLINKARM_CP15_WriteEx.assert_called_once_with(*args)
 
     def test_cp15_register_write_raises_exception_if_CP15_WriteEx_fails(self):
         """Tests that cp15_register_write raises a JLinkException on failure.
@@ -6244,7 +6244,7 @@ class TestJLink(unittest.TestCase):
         args = ['my/file/path']
         self.dll.JLINKARM_SetLogFile.return_value = 0
         self.jlink.set_log_file(*args)
-        assert self.dll.JLINKARM_SetLogFile.called_once_with(*args)
+        assert self.dll.JLINKARM_SetLogFile.assert_called_once_with(*args)
 
     def test_set_log_file_raises_exception_if_SetLogFile_fails(self):
         """Tests that set_log_file raises a JLinkException on failure.

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -6215,10 +6215,11 @@ class TestJLink(unittest.TestCase):
           ``None``
         """
         args = [1, 2, 3, 4, 5]
+        expected = [1, 3, 2, 4, 5]
 
         self.dll.JLINKARM_CP15_WriteEx.return_value = 0
         actual = self.jlink.cp15_register_write(*args)
-        assert self.dll.JLINKARM_CP15_WriteEx.assert_called_once_with(*args)
+        self.dll.JLINKARM_CP15_WriteEx.assert_called_once_with(*expected)
 
     def test_cp15_register_write_raises_exception_if_CP15_WriteEx_fails(self):
         """Tests that cp15_register_write raises a JLinkException on failure.
@@ -6242,9 +6243,10 @@ class TestJLink(unittest.TestCase):
           ``None``
         """
         args = ['my/file/path']
+        expected = [b'my/file/path']
         self.dll.JLINKARM_SetLogFile.return_value = 0
         self.jlink.set_log_file(*args)
-        assert self.dll.JLINKARM_SetLogFile.assert_called_once_with(*args)
+        self.dll.JLINKARM_SetLogFile.assert_called_once_with(*expected)
 
     def test_set_log_file_raises_exception_if_SetLogFile_fails(self):
         """Tests that set_log_file raises a JLinkException on failure.

--- a/tests/unit/test_library.py
+++ b/tests/unit/test_library.py
@@ -1034,9 +1034,9 @@ class TestLibrary(unittest.TestCase):
 
         mock_find_library.assert_called_once_with(library.Library.JLINK_SDK_OBJECT)
         # JLinkarmDlInfo has not been instantiated.
-        self.assertEquals(0, mock_dlinfo_ctr.call_count)
+        self.assertEqual(0, mock_dlinfo_ctr.call_count)
         # Fallback to "search by file name" has succeeded.
-        self.assertEquals(1, mock_load_library.call_count)
+        self.assertEqual(1, mock_load_library.call_count)
         self.assertEqual(directories[0], lib._path)
 
     @mock.patch('os.name', new='posix')
@@ -1080,9 +1080,9 @@ class TestLibrary(unittest.TestCase):
 
         mock_find_library.assert_any_call(library.Library.JLINK_SDK_OBJECT)
         mock_find_library.assert_any_call('dl')
-        self.assertEquals(2, mock_find_library.call_count)
+        self.assertEqual(2, mock_find_library.call_count)
         # Called once in JLinkarmDlInfo and once in Library.
-        self.assertEquals(2, mock_load_library.call_count)
+        self.assertEqual(2, mock_load_library.call_count)
         # The dlinfo() dance silently failed, but will answer None resolved path.
         self.assertIsNone(library.Library._dlinfo.path)
         # Fallback to "search by file name" has succeeded.
@@ -1121,8 +1121,8 @@ class TestLibrary(unittest.TestCase):
 
         mock_find_library.assert_any_call(library.Library.JLINK_SDK_OBJECT)
         mock_find_library.assert_any_call('dl')
-        self.assertEquals(2, mock_find_library.call_count)
-        self.assertEquals(2, mock_load_library.call_count)
+        self.assertEqual(2, mock_find_library.call_count)
+        self.assertEqual(2, mock_load_library.call_count)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Renamed test function calls that are removed in Python 3.
Fixed some test cases that likely were broken but failure was masked by calling an invalid function.
Closes #197
