### PR TITLE
[ISSUE-214] Add Support for Power Tracing

### DIFF
--- a/pylink/__main__.py
+++ b/pylink/__main__.py
@@ -17,8 +17,11 @@ import pylink
 import argparse
 import logging
 import os
-import six
 import sys
+try:
+    from six.moves import with_metaclass
+except (AttributeError, ImportError):
+    from six import with_metaclass
 
 
 class CommandMeta(type):
@@ -49,7 +52,7 @@ class CommandMeta(type):
         return newClass
 
 
-class Command(six.with_metaclass(CommandMeta)):
+class Command(with_metaclass(CommandMeta)):
     """Base command-class.
 
     All commands should inherit from this class.

--- a/pylink/enums.py
+++ b/pylink/enums.py
@@ -734,6 +734,7 @@ class JLinkPowerTraceCommand(object):
     GET_CHANNEL_CAPS = 5
     GET_NUM_ITEMS = 6
 
+
 class JLinkPowerTraceRef(object):
     """Reference values to store on power trace capture.
 

--- a/pylink/enums.py
+++ b/pylink/enums.py
@@ -722,3 +722,27 @@ class JLinkRTTDirection(object):
     """RTT Direction."""
     UP = 0
     DOWN = 1
+
+
+class JLinkPowerTraceCommand(object):
+    """Power trace commands."""
+    SETUP = 0
+    START = 1
+    FLUSH = 2
+    STOP = 3
+    GET_CAPS = 4
+    GET_CHANNEL_CAPS = 5
+    GET_NUM_ITEMS = 6
+
+class JLinkPowerTraceRef(object):
+    """Reference values to store on power trace capture.
+
+    Attributes:
+        NONE: No reference value is stored.
+        BYTES: Number of bytes transferred via SWO is stored since capturing
+            started.
+        TIME: Number of milliseconds since capturing started.
+    """
+    NONE = 0
+    BYTES = 1
+    TIME = 2

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -5267,7 +5267,7 @@ class JLink(object):
 
         Args:
           self (JLink): the ``JLink`` instance.
-          channels (list[int]): list specifying which channels to capture on (0-7).
+          channels (list[int]): list specifying which channels to capture on (0 - 7).
           freq (int): sampling frequency (in Hertz).
           ref (JLinkPowerTraceRef): reference value to stored on capture.
           always (bool): ``True`` to capture data even while CPU halted, otherwise ``False``.
@@ -5277,6 +5277,7 @@ class JLink(object):
 
         Raises:
           JLinkException: on error
+          ValueError: invalid channels specified
         """
         if isinstance(channels, list):
             channel_mask = 0x00
@@ -5284,6 +5285,9 @@ class JLink(object):
                 channel_mask |= (1 << channel)
         else:
             channel_mask = channels
+
+        if channel_mask > 0xFF:
+            raise ValueError("Channels must be in range 0 - 7")
 
         setup = structs.JLinkPowerTraceSetup()
         setup.ChannelMask = channel_mask
@@ -5386,6 +5390,7 @@ class JLink(object):
 
         Raises:
           JLinkException: on error
+          ValueError: invalid channels specified
         """
         if isinstance(channels, list):
             channel_mask = 0x00
@@ -5393,6 +5398,9 @@ class JLink(object):
                 channel_mask |= (1 << channel)
         else:
             channel_mask = channels
+
+        if channel_mask > 0xFF:
+            raise ValueError("Channels must be in range 0 - 7")
 
         channel_caps = structs.JLinkPowerTraceChannelCaps()
         caps = structs.JLinkPowerTraceCaps()

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -5250,3 +5250,213 @@ class JLink(object):
         if res != 0:
             raise errors.JLinkException(res)
         return res
+
+###############################################################################
+#
+# Power API
+#
+###############################################################################
+    @open_required
+    def power_trace_configure(self, channels, freq, ref, always):
+        """Configures power tracing.
+
+        This method must be called before calling the other power trace APIs. It
+        is the responsibility of the calling application code to keep track of
+        which channels were enabled in order to determine which trace samples
+        correspond to which channels when read.
+
+        Args:
+          self (JLink): the ``JLink`` instance.
+          channels (list[int]): list specifying which channels to capture on (0-7).
+          freq (int): sampling frequency (in Hertz).
+          ref (JLinkPowerTraceRef): reference value to stored on capture.
+          always (bool): ``True`` to capture data even while CPU halted, otherwise ``False``.
+
+        Returns:
+          The sampling frequency (in Hz) for power sampling.
+
+        Raises:
+          JLinkException: on error
+        """
+        if isinstance(channels, list):
+            channel_mask = 0x00
+            for channel in channels:
+                channel_mask |= (1 << channel)
+        else:
+            channel_mask = channels
+
+        setup = structs.JLinkPowerTraceSetup()
+        setup.ChannelMask = channel_mask
+        setup.SampleFreq = int(freq)
+        setup.RefSelect = int(ref)
+        setup.EnableCond = 0 if always else 1
+
+        res = self._dll.JLINK_POWERTRACE_Control(enums.JLinkPowerTraceCommand.SETUP, ctypes.byref(setup), 0)
+        if res < 0:
+            raise errors.JLinkException(res)
+        return res
+
+    @open_required
+    def power_trace_start(self):
+        """Starts capturing data on the channels enabled via ``power_trace_configure()``.
+
+        Args:
+          self (JLink): the ``JLink`` instance.
+
+        Returns:
+          ``None``
+
+        Raises:
+          JLinkException: on error
+        """
+        res = self._dll.JLINK_POWERTRACE_Control(enums.JLinkPowerTraceCommand.START, 0, 0)
+        if res < 0:
+            raise errors.JLinkException(res)
+
+    @open_required
+    def power_trace_stop(self):
+        """Stops a capture started by ``power_trace_start()``.
+
+        Args:
+          self (JLink): the ``JLink`` instance.
+
+        Returns:
+          ``None``
+
+        Raises:
+          JLinkException: on error
+        """
+        res = self._dll.JLINK_POWERTRACE_Control(enums.JLinkPowerTraceCommand.STOP, 0, 0)
+        if res < 0:
+            raise errors.JLinkException(res)
+
+    @open_required
+    def power_trace_flush(self):
+        """Flushes all capture data.
+
+        Any data that has not been read by ``power_trace_read()`` is dropped.
+
+        Args:
+          self (JLink): the ``JLink`` instance.
+
+        Returns:
+          ``None``
+
+        Raises:
+          JLinkException: on error
+        """
+        res = self._dll.JLINK_POWERTRACE_Control(enums.JLinkPowerTraceCommand.FLUSH, 0, 0)
+        if res < 0:
+            raise errors.JLinkException(res)
+
+    @open_required
+    def power_trace_get_channels(self):
+        """Returns a list of the available channels for power tracing.
+
+        This method returns a list of the available channels for power tracing.
+        The application code can use this to determine which channels to
+        enable for tracing.
+
+        Args:
+          self (JLink): the ``JLink`` instance.
+
+        Returns:
+          List of available channel identifiers.
+
+        Raises:
+          JLinkException: on error
+        """
+        caps = structs.JLinkPowerTraceCaps()
+        res = self._dll.JLINK_POWERTRACE_Control(enums.JLinkPowerTraceCommand.GET_CAPS, 0, ctypes.byref(caps))
+        if res < 0:
+            raise errors.JLinkException(res)
+
+        return [i for i in range(0, 32) if (caps.ChannelMask >> i) & 0x1]
+
+    @open_required
+    def power_trace_get_channel_capabilities(self, channels):
+        """Returns the capabilities for the specified channels.
+
+        Args:
+          self (JLink): the ``JLink`` instance.
+          channels (list[int]): list specifying which channels to get capabilities for.
+
+        Returns:
+          Channel capabilities.
+
+        Raises:
+          JLinkException: on error
+        """
+        if isinstance(channels, list):
+            channel_mask = 0x00
+            for channel in channels:
+                channel_mask |= (1 << channel)
+        else:
+            channel_mask = channels
+
+        channel_caps = structs.JLinkPowerTraceChannelCaps()
+        caps = structs.JLinkPowerTraceCaps()
+        caps.ChannelMask = channel_mask
+
+        res = self._dll.JLINK_POWERTRACE_Control(enums.JLinkPowerTraceCommand.GET_CHANNEL_CAPS,
+                                                 ctypes.byref(caps),
+                                                 ctypes.byref(channel_caps))
+        if res < 0:
+            raise errors.JLinkException(res)
+
+        return channel_caps
+
+    @open_required
+    def power_trace_get_num_items(self):
+        """Returns a count of the number of items in the power trace buffer.
+
+        Since each channel is sampled simulataneously, the count of number of
+        items per channel is the return value of this function divided by the
+        number of active channels.
+
+        Args:
+          self (JLink): the ``JLink`` instance.
+
+        Returns:
+          Number of items in the power trace buffer.
+
+        Raises:
+          JLinkException: on error
+        """
+        res = self._dll.JLINK_POWERTRACE_Control(enums.JLinkPowerTraceCommand.GET_NUM_ITEMS, 0, 0)
+        if res < 0:
+            raise errors.JLinkException(res)
+        return res
+
+    @open_required
+    def power_trace_read(self, num_items=None):
+        """Reads data from the power trace buffer.
+
+        Any read data is flushed from the power trace buffer.
+
+        Args:
+          self (JLink): the ``JLink`` instance.
+          num_items (int): the number of items to read (if not specified, reads all).
+
+        Returns:
+          List of ``JLinkPowerTraceItem``s.
+
+        Raises:
+          JLinkException: on error
+        """
+        if num_items is None:
+            num_items = self.power_trace_get_num_items()
+
+        items = []
+        if num_items < 0:
+            raise ValueError("Invalid number of items requested, expected > 0, given %d" % num_items)
+        elif num_items > 0:
+            items = (structs.JLinkPowerTraceItem * num_items)()
+            res = self._dll.JLINK_POWERTRACE_Read(ctypes.byref(items), num_items)
+            if res < 0:
+                raise errors.JLinkException(res)
+
+            # Number of items may be less than the requested count, so clip the
+            # array here.
+            items = list(items)[:res]
+        return items

--- a/pylink/structs.py
+++ b/pylink/structs.py
@@ -1261,3 +1261,210 @@ class JLinkRTTerminalStatus(ctypes.Structure):
         return 'Status <NumUpBuffers=%d, NumDownBuffers=%d, Running=%s>' % (self.NumUpBuffers,
                                                                             self.NumDownBuffers,
                                                                             self.IsRunning)
+
+
+class JLinkPowerTraceSetup(ctypes.Structure):
+    """Structure used to setup the power tracing.
+
+    Attributes:
+      SizeOfStruct: Size of the struct (DO NOT CHANGE).
+      ChannelMask: Bitmask indicating which channels to enable for capturing.
+      SampleFreq: Sampling frequency in Hertz.
+      RefSelect: Identifier of the reference value stored with every trace
+        (see ``enums.JLinkPowerTraceRef``).
+      EnableCond: `1` is tracing is only captured when CPU is running.
+    """
+    _fields_ = [
+        ('SizeOfStruct', ctypes.c_int32),
+        ('ChannelMask', ctypes.c_uint32),
+        ('SampleFreq', ctypes.c_uint32),
+        ('RefSelect', ctypes.c_int32),
+        ('EnableCond', ctypes.c_int32)
+    ]
+
+    def __init__(self):
+        """Initializes the ``JLinkPowerTraceSetup`` instance.
+
+        Sets the size of the structure.
+
+        Args:
+          self (JLinkPowerTraceSetup): the power trace instance.
+
+        Returns:
+          ``None``
+        """
+        super(JLinkPowerTraceSetup, self).__init__()
+        self.SizeOfStruct = ctypes.sizeof(self)
+
+    def __repr__(self):
+        """Returns a string representation of the instance.
+
+        Args:
+          self (JLinkPowerTraceSetup): the ``JLinkPowerTraceSetup`` instance
+
+        Returns:
+          String representation of the instance.
+        """
+        return self.__str__()
+
+    def __str__(self):
+        """Returns this instance formatted as a string.
+
+        Args:
+          self (JLinkPowerTraceSetup): the ``JLinkPowerTraceSetup`` instance
+
+        Returns:
+          String formatted instance.
+        """
+        return '%s(Channel Mask=%s, Freq=%uHz)' % (self.__class__.__name__, bin(self.ChannelMask), self.SampleFreq)
+
+
+class JLinkPowerTraceItem(ctypes.Structure):
+    """Structure used to represent a stored power trace item.
+
+    Attributes:
+      RefValue: the stored reference value.
+      Value: the actual recorded trace value.
+    """
+    _fields_ = [
+        ('RefValue', ctypes.c_uint32),
+        ('Value', ctypes.c_uint32)
+    ]
+
+    def __repr__(self):
+        """Returns a string representation of the instance.
+
+        Args:
+          self (JLinkPowerTraceItem): the ``JLinkPowerTraceItem`` instance
+
+        Returns:
+          String representation of the instance.
+        """
+        return self.__str__()
+
+    def __str__(self):
+        """Returns this instance formatted as a string.
+
+        Args:
+          self (JLinkPowerTraceItem): the ``JLinkPowerTraceItem`` instance
+
+        Returns:
+          String formatted instance.
+        """
+        return '%s(Value=%u, Reference=%u)' % (self.__class__.__name__, self.Value, self.RefValue)
+
+
+class JLinkPowerTraceCaps(ctypes.Structure):
+    """Structure used to retrieve or specify available power tracing channels.
+
+    Attributes:
+      SizeOfStruct: the size of this structure (in bytes).
+      ChannelMask: bitmask of available channels.
+    """
+    _fields_ = [
+        ('SizeOfStruct', ctypes.c_int32),
+        ('ChannelMask', ctypes.c_uint32)
+    ]
+
+    def __init__(self):
+        """Initializes the ``JLinkPowerTraceCaps`` instance.
+
+        Sets the size of the structure.
+
+        Args:
+          self (JLinkPowerTraceCaps): the power trace caps instance.
+
+        Returns:
+          ``None``
+        """
+        super(JLinkPowerTraceCaps, self).__init__()
+        self.SizeOfStruct = ctypes.sizeof(self)
+
+    def __repr__(self):
+        """Returns a string representation of the instance.
+
+        Args:
+          self (JLinkPowerTraceCaps): the caps instance.
+
+        Returns:
+          String representation of the instance.
+        """
+        return self.__str__()
+
+    def __str__(self):
+        """Returns this instance formatted as a string.
+
+        Args:
+          self (JLinkPowerTraceCaps): the caps instance.
+
+        Returns:
+          String formatted instance.
+        """
+        return '%s(Channel Mask=%s)' % (self.__class__.__name__, bin(self.ChannelMask))
+
+
+class JLinkPowerTraceChannelCaps(ctypes.Structure):
+    """Structure representing the capabilities for the queried channels.
+
+    Attributes:
+      SizeOfStruct: the size of this structure (in bytes).
+      BaseSampleFreq: the base sampling frequeny (in Hertz).
+      MinDiv: the minimum divider of the base sampling frequency.
+    """
+    _fields_ = [
+        ('SizeOfStruct', ctypes.c_int32),
+        ('BaseSampleFreq', ctypes.c_uint32),
+        ('MinDiv', ctypes.c_uint32)
+    ]
+
+    def __init__(self):
+        """Initializes the ``JLinkPowerTraceChannelCaps`` instance.
+
+        Sets the size of the structure.
+
+        Args:
+          self (JLinkPowerTraceChannelCaps): the channel capabilities.
+
+        Returns:
+          ``None``
+        """
+        super(JLinkPowerTraceChannelCaps, self).__init__()
+        self.SizeOfStruct = ctypes.sizeof(self)
+
+    @property
+    def max_sample_freq(self):
+        """Returns the maximum sample frequency that can be used.
+
+        The maximum sampling frequency is the largest frequency that can be
+        specified when configuring power tracing, and is computed based on the
+        minimum divider and base sampling frequency.
+
+        Args:
+          self (JLinkPowerTraceChannelCaps): the channel capabilities.
+
+        Returns:
+          ``float``
+        """
+        return (self.BaseSampleFreq * 1.0) / self.MinDiv
+
+    def __repr__(self):
+        """Returns a string representation of the instance.
+
+        Args:
+          self (JLinkPowerTraceChannelCaps): the channel capabilities.
+
+        Returns:
+          String representation of the instance.
+        """
+        return self.__str__()
+
+    def __str__(self):
+        """Returns this instance formatted as a string.
+
+        Args:
+          self (JLinkPowerTraceChannelCaps): the channel capabilities.
+
+        Returns:
+          String formatted instance.
+        """
+        return '%s(SampleFreq=%uHz, MinDiv=%u)' % (self.__class__.__name__, self.BaseSampleFreq, self.MinDiv)

--- a/tests/unit/test_structs.py
+++ b/tests/unit/test_structs.py
@@ -464,6 +464,69 @@ class TestStructs(unittest.TestCase):
         self.assertEqual('JLinkRTTerminalStatus(NumUpBuffers=3, NumDownBuffers=3)', repr(stat))
         self.assertEqual('Status <NumUpBuffers=3, NumDownBuffers=3, Running=1>', str(stat))
 
+    def test_jlink_power_trace_setup(self):
+        """Validates the ``JLinkPowerTraceSetup`` serializes correctly.
+
+        Args:
+          self (TestStructs): the ``TestStructs`` instance
+
+        Returns:
+          ``None``
+        """
+        setup = structs.JLinkPowerTraceSetup()
+        setup.ChannelMask = 0x3
+        setup.SampleFreq = 1000
+
+        self.assertEqual(20, setup.SizeOfStruct)
+        self.assertEqual('JLinkPowerTraceSetup(Channel Mask=0b11, Freq=1000Hz)', repr(setup))
+
+    def test_jlink_power_trace_item(self):
+        """Validates the ``JLinkPowerTraceItem`` serializes correctly.
+
+        Args:
+          self (TestStructs): the ``TestStructs`` instance
+
+        Returns:
+          ``None``
+        """
+        item = structs.JLinkPowerTraceItem()
+        item.RefValue = 0xDEADBEEF
+        item.Value = 13
+
+        self.assertEqual('JLinkPowerTraceItem(Value=13, Reference=3735928559)', repr(item))
+
+    def test_jlink_power_trace_caps(self):
+        """Validates that the ``JLinkPowerTraceCaps`` serializes correctly.
+
+        Args:
+          self (TestStructs): the ``TestStructs`` instance
+
+        Returns:
+          ``None``
+        """
+        caps = structs.JLinkPowerTraceCaps()
+        caps.ChannelMask = 0x3
+
+        self.assertEqual(8, caps.SizeOfStruct)
+        self.assertEqual('JLinkPowerTraceCaps(Channel Mask=0b11)', repr(caps))
+
+    def test_jlink_power_trace_channel_caps(self):
+        """Validates the ``JLinkPowerTraceChannelCaps`` instance.
+
+        Args:
+          self (TestStructs): the ``TestStructs`` instance
+
+        Returns:
+          ``None``
+        """
+        channel_caps = structs.JLinkPowerTraceChannelCaps()
+        channel_caps.BaseSampleFreq = 1000
+        channel_caps.MinDiv = 4
+
+        self.assertEqual(12, channel_caps.SizeOfStruct)
+        self.assertEqual(250, channel_caps.max_sample_freq)
+        self.assertEqual('JLinkPowerTraceChannelCaps(SampleFreq=1000Hz, MinDiv=4)', repr(channel_caps))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## [ISSUE-214] Add Support for Power Tracing
### Overview

This PR adds support to PyLink for using the Power Trace API. Example usage:

```
import time

import pylink
import pylink.enums


if __name__ == "__main__":
    jl = pylink.JLink()
    jl.open()

    try:
        channels = jl.power_trace_get_channels()
        print(f"{channels=}")

        channel_caps = jl.power_trace_get_channel_capabilities(channels)
        print(f"{channel_caps=}")

        freq = jl.power_trace_configure(channels, channel_caps.max_sample_freq / 10, pylink.enums.JLinkPowerTraceRef.TIME, True)
        print(f"{freq=}")

        jl.power_trace_start()
        time.sleep(0.1)

        num_items = jl.power_trace_get_num_items()
        print(f"{num_items=}")

        items = jl.power_trace_read(num_items)
        print(f"{items=}")

        jl.power_trace_flush()
        jl.power_trace_stop()
    finally:
        jl.close()
```

### Summary of Changes
1. Updated `pylink/__main__.py` to handle old and new `six` with `with_metaclass`.
2. Added power trace enums.
3. Added power trace API methods.
4. Added power trace structures.
5. Updated unit tests.