### PR TITLE
Dynamically determine value of `use_tmpcpy` based on library version

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,3 +24,4 @@ In the order of appearance in the commit history:
 | Dominic Shelton           | @frogamic          |
 | Fletcher D                | @FletcherD         |
 | G Towers                  | @gtowers-dukosi    |
+| Ben Brown                 | @bbrown1867        |

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -247,7 +247,7 @@ class JLink(object):
         return _interface_required
 
     def __init__(self, lib=None, log=None, detailed_log=None, error=None, warn=None, unsecure_hook=None,
-                 serial_no=None, ip_addr=None, open_tunnel=False, use_tmpcpy=True):
+                 serial_no=None, ip_addr=None, open_tunnel=False, use_tmpcpy=None):
         """Initializes the J-Link interface object.
 
         Note:
@@ -279,7 +279,8 @@ class JLink(object):
             of ``open`` method.
             If ``None``, the driver will not be opened automatically
             (however, it is still closed when exiting the context manager).
-          use_tmpcpy (bool): True to load a temporary copy of J-Link DLL
+          use_tmpcpy (Optional[bool]): ``True`` to load a temporary copy of
+            J-Link DLL, ``None`` to dynamically decide based on DLL version.
 
         Returns:
           ``None``

--- a/tests/unit/test_library.py
+++ b/tests/unit/test_library.py
@@ -1124,6 +1124,18 @@ class TestLibrary(unittest.TestCase):
         self.assertEqual(2, mock_find_library.call_count)
         self.assertEqual(2, mock_load_library.call_count)
 
+    @mock.patch('ctypes.cdll.LoadLibrary')
+    def test_dll_version_linux(self, _mock_load_library):
+        path = "/opt/SEGGER/JLink_Linux_V684b_x86_64/libjlinkarm.so"
+        lib = library.Library(path)
+        self.assertEqual(lib.dll_version(), 6.84)
+
+    @mock.patch('ctypes.cdll.LoadLibrary')
+    def test_dll_version_mac(self, _mock_load_library):
+        path = "/Applications/SEGGER/JLink_V796n/libjlinkarm.dylib"
+        lib = library.Library(path)
+        self.assertEqual(lib.dll_version(), 7.96)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Instead of defaulting this value to ``True``, this change changes `pylink` to dynamically determine based on DLL version.

Closes #32 and #134.