### PR TITLE
Remove newlines in detailed log messages

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -322,7 +322,7 @@ class JLink(object):
         self.error_handler = lambda s: (error or logger.error)(s.decode(errors='replace'))
         self.warning_handler = lambda s: (warn or logger.warning)(s.decode(errors='replace'))
         self.log_handler = lambda s: (log or logger.info)(s.decode(errors='replace'))
-        self.detailed_log_handler = lambda s: (detailed_log or logger.debug)(s.decode(errors='replace'))
+        self.detailed_log_handler = lambda s: (detailed_log or logger.debug)(s.decode(errors='replace').rstrip())
 
         # Parameters used for open() in context manager
         self.__serial_no = serial_no


### PR DESCRIPTION
The (officially deprecated, but still working) JLINKARM_EnableLogCom adds newlines add the end of every message that clobber the log output. Use rstrip() to remove the newlines.