### PR TITLE
[ISSUE-241] Fix Exception Type Raised in `.flash()`

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -2225,7 +2225,7 @@ class JLink(object):
 
         res = self._dll.JLINKARM_EndDownload()
         if res < 0:
-            raise errors.JLinkEraseException(res)
+            raise errors.JLinkFlashException(res)
 
         return bytes_flashed
 


### PR DESCRIPTION
## [ISSUE-241] Fix Exception Type Raised in `.flash()`
### Overview
This patch fixes the wrong exception being raised in the `.flash()` function; currently is `JLinkEraseException()`, is now `JLinkFlashException()`.