### PR TITLE
[ISSUE-232] Add JTAG APIs

### DIFF
--- a/pylink/structs.py
+++ b/pylink/structs.py
@@ -1468,3 +1468,54 @@ class JLinkPowerTraceChannelCaps(ctypes.Structure):
           String formatted instance.
         """
         return '%s(SampleFreq=%uHz, MinDiv=%u)' % (self.__class__.__name__, self.BaseSampleFreq, self.MinDiv)
+
+
+class JLinkJTAGDeviceInfo(ctypes.Structure):
+    """Structure representing the information of a device on the JTAG scan chain.
+
+    Attributes:
+      sName: the name of the device.
+      IRLen: instruction register length.
+      IRPrint: instruction register print.
+      DeviceId: JTAG id.
+    """
+    _fields_ = [
+        ('sName', ctypes.c_char_p),
+        ('IRLen', ctypes.c_uint32),
+        ('IRPrint', ctypes.c_uint32),
+        ('DeviceId', ctypes.c_uint32)
+    ]
+
+    def __repr__(self):
+        """Returns a representation of this instance.
+
+        Args:
+          self (JLinkJTAGDeviceInfo): the ``JLinkJTAGDeviceInfo`` instance
+
+        Returns:
+          Returns a string representation of the instance.
+        """
+        return 'JLinkJTAGDeviceInfo(%s)' % self.__str__()
+
+    def __str__(self):
+        """Returns a string representation of this instance.
+
+        Args:
+          self (JLinkJTAGDeviceInfo): the ``JLinkJTAGDeviceInfo`` instance
+
+        Returns:
+          Returns a string specifying the device name and ID.
+        """
+        return '%s <Device Id. %s>' % (self.name, self.DeviceId)
+
+    @property
+    def name(self):
+        """Returns the name of the JTAG device.
+
+        Args:
+          self (JLinkJTAGDeviceInfo): the ``JLinkJTAGDeviceInfo`` instance
+
+        Returns:
+          Device name.
+        """
+        return ctypes.cast(self.sName, ctypes.c_char_p).value.decode()

--- a/tests/unit/test_jlink.py
+++ b/tests/unit/test_jlink.py
@@ -3297,6 +3297,111 @@ class TestJLink(unittest.TestCase):
         self.jlink.jtag_flush()
         self.dll.JLINKARM_WriteBits.assert_called_once()
 
+    def test_jlijnk_jtag_store_instruction(self):
+        """Tests the J-Link JTAG method for storing a JTAG instruction.
+
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        cmd = 0xE
+        self.jlink.jtag_store_instruction(cmd, 4)
+
+        c_byte, num_bits = self.dll.JLINKARM_JTAG_StoreInst.call_args[0]
+        self.assertEqual(4, num_bits)
+
+        c_uint = ctypes.cast(c_byte, ctypes.POINTER(ctypes.c_uint8)).contents
+        self.assertEqual(cmd, c_uint.value)
+
+    def test_jlink_jtag_store_data(self):
+        """Tests the J-Link JTAG method for storing TDI.
+
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        tdi = [0xA, 0x3]
+        self.jlink.jtag_store_data(tdi, 5)
+
+        buf, num_bits = self.dll.JLINKARM_JTAG_StoreData.call_args[0]
+        self.assertEqual(10, num_bits)
+        self.assertEqual(b'\x0A\x03', bytearray(buf))
+
+    def test_jlink_jtag_get_device_info(self):
+        """Tests the J-Link JTAG method for retrieving JTAG device information.
+
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Return:
+          ``None``
+        """
+        with self.assertRaises(ValueError):
+            _ = self.jlink.jtag_get_device_info(-1)
+
+        self.dll.JLINKARM_JTAG_GetDeviceInfo.return_value = -1
+        with self.assertRaises(ValueError):
+            _ = self.jlink.jtag_get_device_info(0)
+
+        def _get_device_info(index, info):
+            c_info = ctypes.cast(info, ctypes.POINTER(structs.JLinkJTAGDeviceInfo)).contents
+            c_info.IRLen = 0x1
+            c_info.IRPrint = 0x2
+            c_info.DeviceId = 0x1337
+            name = b"Silk Song"
+            c_info.sName = ctypes.cast(name, ctypes.c_char_p)
+            return 0
+
+        self.dll.JLINKARM_JTAG_GetDeviceInfo = _get_device_info
+        self.dll.JLINKARM_JTAG_GetDeviceId.return_value = 0x1337
+
+        info = self.jlink.jtag_get_device_info(0)
+        self.assertEqual(0x1337, info.DeviceId)
+        self.assertEqual(0x1, info.IRLen)
+        self.assertEqual(0x2, info.IRPrint)
+        self.assertEqual("Silk Song", info.name)
+
+    def test_jlink_jtag_read(self):
+        """Tests the J-Link JTAG read methods.
+
+        Args:
+          self (TestJLink): the ``TestJLink`` instance
+
+        Returns:
+          ``None``
+        """
+        self.jlink._tif = enums.JLinkInterfaces.JTAG
+
+        val = 0x12345678
+        self.dll.JLINKARM_JTAG_GetU8.return_value = val & 0xFF
+        self.dll.JLINKARM_JTAG_GetU16.return_value = val & 0xFFFF
+        self.dll.JLINKARM_JTAG_GetU32.return_value = val & 0xFFFFFFFF
+
+        self.assertEqual(0x78, self.jlink.jtag_read8(0))
+        self.assertEqual(0x5678, self.jlink.jtag_read16(0))
+        self.assertEqual(0x12345678, self.jlink.jtag_read32(0))
+
+        def _get_data(buf, offset, num_bits):
+            c_buf = ctypes.cast(buf, ctypes.POINTER(ctypes.c_uint8))
+            buf_index = 0
+            bit_index = 0
+            while num_bits:
+                rd_size = min(num_bits, 4)
+                num_bits -= rd_size
+                b = 0
+                for i in range(0, rd_size):
+                    b |= ((val & (0x1 << bit_index)) >> bit_index) << i
+                    bit_index += 1
+                c_buf[buf_index] = b
+                buf_index += 1
+
+        self.dll.JLINKARM_JTAG_GetData = _get_data
+        self.assertEqual([0x8, 0x7, 0x6, 0x5], self.jlink.jtag_read(0, 16))
+
     def test_jlink_swd_read8(self):
         """Tests the J-Link ``swd_read8()`` method.
 


### PR DESCRIPTION
## [ISSUE-232] Add JTAG APIs
### Overview
This PR adds JTAG APIs for executing instructions and sending data directly to devices over the JTAG scan chain. Several new APIs have been added:

* `jtag_store_instruction` - To send an instruction to the JTAG device.
* `jtag_store_data` - To send data to the JTAG device (TDO).
* `jtag_get_device_info` - To get information about a JTAG device on the scan chain.
* `jtag_read` / `jtag_read{8,16,32}` - To read data from a JTAG device (from the input buffer / TDI).
* `jtag_sync_bits` / `jtag_sync_bytes` - To force a flush of the output buffer.

By default, instructions and data are stored in an internal buffer and only sent to the JTAG device when a read is performed or an explicit flush is done. This is done internally by the debugger to increase performance (read: speed).

### Summary of Changes
1. Added new JTAG APIs.
2. Updated unit tests.
3. Added JTAG device info structure.