### PR TITLE
Fix exec command

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,3 +30,4 @@ In the order of appearance in the commit history:
 | -                         | @mtnpke            |
 | Omri Sarig                | @omrisarig13       |
 | Issam E. Maghni           | @concatime         |
+| Patrik Bachan             | @diggit            |

--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -943,6 +943,7 @@ class JLink(object):
 
         return None
 
+    @open_required
     def exec_command(self, cmd):
         """Executes the given command.
 


### PR DESCRIPTION
If `exec_command` is called before `open`, DLL opens connection to _some_ probe it picks, which then causes issues when `open` is called afterwards.

resolves #254