### PR TITLE
test: fix windows init test on 32-bit runners

### DIFF
--- a/tests/unit/test_library.py
+++ b/tests/unit/test_library.py
@@ -216,6 +216,7 @@ class TestLibrary(unittest.TestCase):
         mock_load_library.assert_called_once()
 
     @mock.patch('sys.platform', new='windows')
+    @mock.patch('sys.maxsize', new=(2**63-1))
     @mock.patch('pylink.library.open')
     @mock.patch('os.remove', new=mock.Mock())
     @mock.patch('tempfile.NamedTemporaryFile', new=mock.Mock())


### PR DESCRIPTION
Fixes #256

### Problem
`TestLibrary.test_initialize_windows` assumes a 64-bit Python runtime, but it only patches `sys.platform`. On 32-bit runners (e.g. Arch Linux ARM 32-bit), `sys.maxsize` indicates 32-bit and the code correctly selects `JLinkARM` instead of `JLink_x64`, causing the test to fail.

### Solution
Patch `sys.maxsize` in the 64-bit Windows test to explicitly model the intended runtime. The 32-bit variant is already covered by `test_initialize_windows_32bit`.

### Testing
`PYTHONPATH=. python -m unittest -q`
