### PR TITLE
Fix positional argument passing to JLINKARM_BeginDownload

### DIFF
--- a/pylink/jlink.py
+++ b/pylink/jlink.py
@@ -2215,7 +2215,7 @@ class JLink(object):
             pass
 
         # Perform read-modify-write operation.
-        self._dll.JLINKARM_BeginDownload(flags=flags)
+        self._dll.JLINKARM_BeginDownload(flags)
 
         if isinstance(data, list):
             data = bytes(data)


### PR DESCRIPTION
ctypes ignores the flags keyword argument, leaving the native function without its argument. Pass flags positionally so it receives zero.

fixes https://github.com/square/pylink/issues/269